### PR TITLE
allow PropTypes.node for labels

### DIFF
--- a/InstanceSearch/InstanceSearch.js
+++ b/InstanceSearch/InstanceSearch.js
@@ -67,7 +67,7 @@ InstanceSearch.defaultProps = {
 };
 
 InstanceSearch.propTypes = {
-  searchLabel: PropTypes.string,
+  searchLabel: PropTypes.node,
   searchButtonStyle: PropTypes.string,
   marginBottom0: PropTypes.bool,
   marginTop0: PropTypes.bool,


### PR DESCRIPTION
Allow `PropTypes.node` instead of the more restrictive
`PropTypes.string` for labels that may be passed as `<FormattedMessage>`
objects.