### PR TITLE
UIPFI-23: Update stripes-cli to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Do not show results without performing a query. Fixes UIPFI-17.
 * Update to stripes v6. Refs UIPFI-21.
+* Update to `stripes-cli v2.0.0`. Refs UIPFI-23.
 
 ## [4.0.0](https://github.com/folio-org/ui-plugin-find-instance/tree/v4.0.0) (2020-10-07)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v3.0.0...v4.0.0)

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.0.0",
     "@folio/stripes": "^6.0.0",
-    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-cli": "^2.0.0",
     "babel-eslint": "^10.0.1",
     "chai": "^4.2.0",
     "core-js": "^3.6.1",


### PR DESCRIPTION
# Description
Update `stripes-cli` to `v2.0.0`

# Task
https://issues.folio.org/browse/UIPFI-23
