### PR TITLE
UIPFI-36: Change default search index to align it with the ui-inventory module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [5.1.1] IN PROGRESS
 
-* Fix default search index to align it with the `ui-inventory` module. Fixes UIPFI-36.
+* Change default search index to align it with the `ui-inventory` module. Fixes UIPFI-36.
 
 ## [5.1.0] (https://github.com/folio-org/ui-plugin-find-instance/tree/v5.1.0) (2021-06-15)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v5.0.0...v5.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-find-instance
 
+## [5.1.1] IN PROGRESS
+
+* Fix default search index to align it with the `ui-inventory` module. Fixes UIPFI-36.
+
 ## [5.1.0] (https://github.com/folio-org/ui-plugin-find-instance/tree/v5.1.0) (2021-06-15)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v5.0.0...v5.1.0)
 

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -77,7 +77,7 @@ class FindInstanceContainer extends React.Component {
         params: {
           query: makeQueryFunction(
             'cql.allRecords=1 sortby title',
-            '(title="%{query.query}" or contributors =/@name "%{query.query}" or identifiers =/@value "%{query.query}")',
+            'keyword all "%{query.query}"',
             {},
             filterConfig,
             2,


### PR DESCRIPTION
https://issues.folio.org/browse/UIPFI-36

It looks like the default search index was different from what is used in `ui-inventory`.  This PR is trying to address it.