### PR TITLE
UIPFI-84 use correct css-loader syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [6.1.0] (IN PROGRESS)
 
 * Lookup instances by ids after they are returned from `mod-search`. Fixes UIPFI-83.
+* Use correct `css-loader` syntax. Refs UIPFI-84.
 
 ## [6.0.1] (IN PROGRESS)
 

--- a/Imports/imports/ElasticQueryField/ElasticQueryField.css
+++ b/Imports/imports/ElasticQueryField/ElasticQueryField.css
@@ -9,16 +9,16 @@
 .optionMenu {
   position: absolute;
   width: 100%;
-  composes: multiSelectMenu from '@folio/stripes-components/lib/MultiSelection/MultiSelect.css';
+  composes: multiSelectMenu from '~@folio/stripes-components/lib/MultiSelection/MultiSelect.css';
 }
 
 .optionList {
   max-height: 168px;
-  composes: multiSelectOptionList from '@folio/stripes-components/lib/MultiSelection/MultiSelect.css';
+  composes: multiSelectOptionList from '~@folio/stripes-components/lib/MultiSelection/MultiSelect.css';
 }
 
 .option {
-  composes: option from '@folio/stripes-components/lib/Selection/Selection.css';
+  composes: option from '~@folio/stripes-components/lib/Selection/Selection.css';
 
   &:hover {
     box-shadow: inset 0 0 0 3px var(--primary);
@@ -26,7 +26,7 @@
 }
 
 .optionCursor {
-  composes: optionCursor from '@folio/stripes-components/lib/MultiSelection/MultiSelect.css';
+  composes: optionCursor from '~@folio/stripes-components/lib/MultiSelection/MultiSelect.css';
 }
 
 .info {


### PR DESCRIPTION
Use the correct syntax when linking to styles in other packages.

Refs [UIPFI-84](https://issues.folio.org/browse/UIPFI-84), [STRIPES-770](https://issues.folio.org/browse/STRIPES-770)
