### PR TITLE
UIPFI-87: Close modal only after instance record is refetched

### DIFF
--- a/InstanceSearch/InstanceSearch.js
+++ b/InstanceSearch/InstanceSearch.js
@@ -48,6 +48,7 @@ const InstanceSearch = ({ selectInstance, isMultiSelect, renderNewBtn, onClose, 
     <DataProvider>
       <PluginFindRecord
         {...rest}
+        onClose={onClose}
         selectRecordsCb={list => setInstances(list)}
       >
         {(modalProps) => (

--- a/InstanceSearch/InstanceSearch.js
+++ b/InstanceSearch/InstanceSearch.js
@@ -20,7 +20,7 @@ const query = {
   sort: 'title',
 };
 
-const InstanceSearch = ({ selectInstance, isMultiSelect, renderNewBtn, ...rest }) => {
+const InstanceSearch = ({ selectInstance, isMultiSelect, renderNewBtn, onClose, ...rest }) => {
   const [segment, setSegment] = useState('instances');
   const [instances, setInstances] = useState([]);
   const {
@@ -37,6 +37,10 @@ const InstanceSearch = ({ selectInstance, isMultiSelect, renderNewBtn, ...rest }
       const result = isMultiSelect ? results.map(r => r.data) : results?.[0]?.data;
       selectInstance(result);
       setInstances([]);
+
+      if (onClose) {
+        onClose();
+      }
     }
   }, [isLoading, results, isMultiSelect, selectInstance]);
 
@@ -87,6 +91,7 @@ InstanceSearch.propTypes = {
   selectInstance: PropTypes.func,
   renderNewBtn: PropTypes.func,
   isMultiSelect: PropTypes.bool,
+  onClose: PropTypes.func,
 };
 
 export default InstanceSearch;

--- a/PluginFindRecord/PluginFindRecord.js
+++ b/PluginFindRecord/PluginFindRecord.js
@@ -42,6 +42,7 @@ class PluginFindRecord extends React.Component {
 
   passRecordsOut = records => {
     this.props.selectRecordsCb(records);
+    this.setState({ openModal: false });
   }
 
   passRecordOut = (e, record) => {

--- a/PluginFindRecord/PluginFindRecord.js
+++ b/PluginFindRecord/PluginFindRecord.js
@@ -35,12 +35,13 @@ class PluginFindRecord extends React.Component {
   });
 
   closeModal = () => {
+    const { onClose } = this.props;
     this.setState({ openModal: false });
+    if (onClose) onClose();
   };
 
   passRecordsOut = records => {
     this.props.selectRecordsCb(records);
-    this.closeModal();
   }
 
   passRecordOut = (e, record) => {
@@ -103,6 +104,7 @@ PluginFindRecord.propTypes = {
   searchButtonStyle: PropTypes.string,
   searchLabel: PropTypes.node,
   selectRecordsCb: PropTypes.func,
+  onClose: PropTypes.func,
 };
 
 PluginFindRecord.defaultProps = {

--- a/PluginFindRecord/PluginFindRecord.js
+++ b/PluginFindRecord/PluginFindRecord.js
@@ -35,9 +35,7 @@ class PluginFindRecord extends React.Component {
   });
 
   closeModal = () => {
-    const { onClose } = this.props;
     this.setState({ openModal: false });
-    if (onClose) onClose();
   };
 
   passRecordsOut = records => {
@@ -105,7 +103,6 @@ PluginFindRecord.propTypes = {
   searchButtonStyle: PropTypes.string,
   searchLabel: PropTypes.node,
   selectRecordsCb: PropTypes.func,
-  onClose: PropTypes.func,
 };
 
 PluginFindRecord.defaultProps = {

--- a/test/bigtest/interactors/PluginFindInstanceInteractor.js
+++ b/test/bigtest/interactors/PluginFindInstanceInteractor.js
@@ -4,6 +4,7 @@ import {
   fillable,
   interactor,
   is,
+  isPresent,
   property,
   scoped,
 } from '@bigtest/interactor';
@@ -43,8 +44,14 @@ import ButtonInteractor from './ButtonInteractor';
     isFocused: is(':focus'),
   });
 
+  isModalPresent = isPresent('[data-test-find-records-modal]');
+
   modal = new PluginModalInteractor();
   filter = new OrderLinesFilterInteractor();
+
+  whenModalNotPresent() {
+    return this.when(() => !this.isModalPresent, 5000);
+  }
 }
 
 export default PluginFindInstanceInteractor;

--- a/test/bigtest/network/config.js
+++ b/test/bigtest/network/config.js
@@ -9,6 +9,18 @@ export default function config() {
     return instances.all();
   });
 
+  this.get('/search/instances', (schema) => {
+    const {
+      instances,
+    } = schema;
+
+    return instances.all();
+  });
+
+  this.get('/inventory/instances/:id', (schema, { params }) => {
+    return schema.instances.find(params.id);
+  });
+
   this.get('/instance-types', ({ instanceTypes }) => {
     return instanceTypes.all();
   });

--- a/test/bigtest/tests/find-instance-with-trigger-test.js
+++ b/test/bigtest/tests/find-instance-with-trigger-test.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import setupApplication from '../helpers/helpers';
 import PluginFindInstanceInteractor from '../interactors/PluginFindInstanceInteractor';
 import { onCloseSpy } from '../helpers/PluginHarness';
+import { find } from '@bigtest/interactor';
 
 const INSTANCES_COUNT = 15;
 
@@ -50,6 +51,7 @@ describe('Find instance plugin with single select option', function () {
     describe('select an instance (click on it)', function () {
       beforeEach(async function () {
         await findInstance.modal.instances(1).click();
+        await findInstance.whenModalNotPresent();
       });
 
       it('modal is closed', function () {

--- a/test/bigtest/tests/find-instance-with-trigger-test.js
+++ b/test/bigtest/tests/find-instance-with-trigger-test.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import setupApplication from '../helpers/helpers';
 import PluginFindInstanceInteractor from '../interactors/PluginFindInstanceInteractor';
 import { onCloseSpy } from '../helpers/PluginHarness';
-import { find } from '@bigtest/interactor';
 
 const INSTANCES_COUNT = 15;
 


### PR DESCRIPTION
https://issues.folio.org/browse/UIPFI-87

The changes in https://issues.folio.org/browse/UIPFI-81 required to refetch the full instance record before returning it to a given module. Unfortunately the `onClose` was executing before the refetch was finalized causing to close the modal without an instance record being returned.