### PR TITLE
UIPFI-91: Add posibility to change visible filter fragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 6.2.0 IN PROGRESS
 
 * Only fetch reference data when plugin is opened. Fixes UIPFI-95.
+* Add posibility to change visible filter fragments. Refs UIPFI-91.
 
 ## [6.1.4](https://github.com/folio-org/ui-plugin-find-instance/tree/v6.1.4) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v6.1.3...v6.1.4)

--- a/Imports/imports/FilterNavigation/FilterNavigation.js
+++ b/Imports/imports/FilterNavigation/FilterNavigation.js
@@ -1,41 +1,75 @@
-import React from 'react';
+import React, {
+  useEffect,
+} from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import {
+  isEmpty,
+  uniqBy,
+} from 'lodash';
+
 import {
   ButtonGroup,
   Button,
 } from '@folio/stripes/components';
 
-import { segments } from '../constants';
+import {
+  segments,
+  AVAILABLE_SEGMENTS_TYPES,
+} from '../constants';
 
-const FilterNavigation = ({ segment, setSegment, reset }) => (
-  <ButtonGroup
-    fullWidth
-    data-test-filters-navigation
-  >
-    {
-      Object.keys(segments).map(name => (
-        <Button
-          key={`${name}`}
-          onClick={() => { setSegment(name); reset(); }}
-          buttonStyle={`${segment === name ? 'primary' : 'default'}`}
-          id={`segment-navigation-${name}`}
-        >
-          <FormattedMessage id={`ui-inventory.filters.${name}`} />
-        </Button>
-      ))
+const FilterNavigation = ({
+  availableSegments,
+  segment,
+  setSegment,
+  reset,
+}) => {
+  const uniqAvailableSegments = uniqBy(availableSegments, 'name');
+  const segmentsForRender = isEmpty(uniqAvailableSegments)
+    ? Object.keys(segments)
+    : uniqAvailableSegments.map(section => section.name);
+
+  useEffect(() => {
+    if (!isEmpty(uniqAvailableSegments)) {
+      setSegment(segmentsForRender[0]);
     }
-  </ButtonGroup>
-);
+  }, []);
+
+  if (segmentsForRender.length === 1) {
+    return null;
+  }
+
+  return (
+    <ButtonGroup
+      fullWidth
+      data-test-filters-navigation
+    >
+      {
+        segmentsForRender.map(name => (
+          <Button
+            key={`${name}`}
+            onClick={() => { setSegment(name); reset(); }}
+            buttonStyle={`${segment === name ? 'primary' : 'default'}`}
+            id={`segment-navigation-${name}`}
+          >
+            <FormattedMessage id={`ui-inventory.filters.${name}`} />
+          </Button>
+        ))
+      }
+    </ButtonGroup>
+  );
+};
 
 FilterNavigation.propTypes = {
   reset: PropTypes.func.isRequired,
   segment: PropTypes.string,
   setSegment: PropTypes.func.isRequired,
+  availableSegments: AVAILABLE_SEGMENTS_TYPES,
 };
 
 FilterNavigation.defaultProps = {
   segment: segments.instances,
+  availableSegments: [],
 };
 
 export default FilterNavigation;

--- a/Imports/imports/FilterNavigation/FilterNavigation.test.js
+++ b/Imports/imports/FilterNavigation/FilterNavigation.test.js
@@ -1,0 +1,128 @@
+import React from 'react';
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+} from '@testing-library/react';
+
+import '../../../test/jest/__mock__';
+
+import {
+  ButtonGroup,
+  Button,
+} from '@folio/stripes/components';
+
+import FilterNavigation from './FilterNavigation';
+
+import { segments } from '../constants';
+
+describe('FilterNavigation', () => {
+  const buttonGroupTestId = 'buttonGroup';
+  const mockedSetSegment = jest.fn();
+  const mockedReset = jest.fn();
+  const defaultProps = {
+    reset: mockedReset,
+    setSegment: mockedSetSegment,
+  };
+  const getButton = (segment) => within(screen.getByTestId(buttonGroupTestId)).getByText(`ui-inventory.filters.${segment}`);
+  const testSegments = (segmentsForTest, activeSegment) => {
+    segmentsForTest.forEach((segment, index) => {
+      const number = index + 1;
+
+      it(`should render ${segment} button`, () => {
+        const button = getButton(segment);
+
+        expect(Button).toHaveBeenNthCalledWith(number, expect.objectContaining({
+          buttonStyle: segment === activeSegment ? 'primary' : 'default',
+        }), {});
+        expect(button).toBeInTheDocument();
+      });
+
+      it(`should correctly process click on ${segment} button`, () => {
+        const button = getButton(segment);
+
+        fireEvent.click(button);
+
+        expect(mockedSetSegment).toHaveBeenCalled();
+        expect(mockedReset).toHaveBeenCalled();
+      });
+    });
+  };
+
+  afterEach(() => {
+    Button.mockClear();
+    ButtonGroup.mockClear();
+    mockedReset.mockClear();
+    mockedSetSegment.mockClear();
+  });
+
+  describe('when "availableSegments" is not passed', () => {
+    const segmentsForTest = Object.keys(segments);
+
+    beforeEach(() => {
+      render(
+        <FilterNavigation
+          {...defaultProps}
+        />
+      );
+    });
+
+    testSegments(segmentsForTest, segmentsForTest[0]);
+  });
+
+  describe('when "availableSegments" is passed', () => {
+    describe('and contains only one item', () => {
+      const mockedAvailableSegments = [{
+        name: segments.items,
+      }];
+
+      beforeEach(() => {
+        render(
+          <FilterNavigation
+            {...defaultProps}
+            availableSegments={mockedAvailableSegments}
+            segment={segments.items}
+          />
+        );
+      });
+
+      it('should set passed segment as active', () => {
+        expect(mockedSetSegment).toHaveBeenCalledWith(segments.items);
+      });
+
+      it('should not render "ButtonGroup"', () => {
+        expect(screen.queryByTestId(buttonGroupTestId)).not.toBeInTheDocument();
+      });
+
+      it('should not render any buttons', () => {
+        expect(screen.queryAllByRole('button')).toHaveLength(0);
+      });
+    });
+
+    describe('and contains more than one item', () => {
+      const mockedAvailableSegments = [{
+        name: segments.holdings,
+      }, {
+        name: segments.items,
+      }];
+      const segmentsForTest = mockedAvailableSegments.map(segment => segment.name);
+
+      beforeEach(() => {
+        render(
+          <FilterNavigation
+            {...defaultProps}
+            availableSegments={mockedAvailableSegments}
+            segment={segments.holdings}
+          />
+        );
+      });
+
+      it('should set first passed segment as active', () => {
+        expect(mockedSetSegment).toHaveBeenCalledWith(segments.holdings);
+      });
+
+      testSegments(segmentsForTest, segments.holdings);
+    });
+  });
+});

--- a/Imports/imports/constants.js
+++ b/Imports/imports/constants.js
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 export const itemStatuses = [
   { label: 'ui-inventory.item.status.agedToLost', value: 'Aged to lost' },
   { label: 'ui-inventory.item.status.available', value: 'Available' },
@@ -29,3 +31,13 @@ export const segments = {
 };
 
 export const CQL_FIND_ALL = 'cql.allRecords=1';
+
+export const AVAILABLE_SEGMENTS_TYPES = PropTypes.arrayOf(
+  PropTypes.shape({
+    name: PropTypes.oneOf([segments.instances, segments.holdings, segments.items]),
+  })
+);
+
+export const CONFIG_TYPES = PropTypes.shape({
+  availableSegments: AVAILABLE_SEGMENTS_TYPES,
+});

--- a/InstanceSearch/InstanceSearch.js
+++ b/InstanceSearch/InstanceSearch.js
@@ -14,12 +14,21 @@ import DataContext from '../Imports/imports/DataContext';
 import { getFilterConfig } from '../Imports/imports/filterConfig';
 import useInstancesQuery from '../hooks/useInstancesQuery';
 
+import { CONFIG_TYPES } from '../Imports/imports/constants';
+
 const query = {
   query: '',
   sort: 'title',
 };
 
-const InstanceSearch = ({ selectInstance, isMultiSelect, renderNewBtn, onClose, ...rest }) => {
+const InstanceSearch = ({
+  config,
+  selectInstance,
+  isMultiSelect,
+  renderNewBtn,
+  onClose,
+  ...rest
+}) => {
   const [segment, setSegment] = useState('instances');
   const [instances, setInstances] = useState([]);
   const {
@@ -57,6 +66,7 @@ const InstanceSearch = ({ selectInstance, isMultiSelect, renderNewBtn, onClose, 
                 <PluginFindRecordModal
                   {...viewProps}
                   {...modalProps}
+                  config={config}
                   isMultiSelect={isMultiSelect}
                   renderNewBtn={renderNewBtn}
                   renderFilters={renderer({ ...data, query })}
@@ -79,6 +89,7 @@ InstanceSearch.defaultProps = {
   selectInstance: noop,
   renderNewBtn: noop,
   isMultiSelect: false,
+  config: {},
 };
 
 InstanceSearch.propTypes = {
@@ -90,6 +101,7 @@ InstanceSearch.propTypes = {
   renderNewBtn: PropTypes.func,
   isMultiSelect: PropTypes.bool,
   onClose: PropTypes.func,
+  config: CONFIG_TYPES,
 };
 
 export default InstanceSearch;

--- a/PluginFindRecord/PluginFindRecordModal.js
+++ b/PluginFindRecord/PluginFindRecordModal.js
@@ -32,6 +32,8 @@ import Filters from './Filters';
 import css from './PluginFindRecordModal.css';
 import FilterNavigation from '../Imports/imports/FilterNavigation';
 
+import { CONFIG_TYPES } from '../Imports/imports/constants';
+
 const RESULTS_HEADER = <FormattedMessage id="ui-plugin-find-instance.resultsHeader" />;
 
 const reduceCheckedRecords = (records, isChecked = false) => {
@@ -219,9 +221,12 @@ class PluginFindRecordModal extends React.Component {
       setSegment,
       source,
       visibleColumns,
+      config,
     } = this.props;
     const { checkedMap, isAllChecked } = this.state;
-
+    const {
+      availableSegments,
+    } = config;
     const { records } = data;
     const checkedRecordsLength = Object.keys(checkedMap).length;
     const builtVisibleColumns = isMultiSelect ? ['isChecked', ...visibleColumns] : visibleColumns;
@@ -363,7 +368,12 @@ class PluginFindRecordModal extends React.Component {
                         defaultWidth="25%"
                         paneTitle={<FormattedMessage id="stripes-smart-components.searchAndFilter" />}
                       >
-                        <FilterNavigation segment={segment} setSegment={setSegment} reset={resetAll} />
+                        <FilterNavigation
+                          availableSegments={availableSegments}
+                          segment={segment}
+                          setSegment={setSegment}
+                          reset={resetAll}
+                        />
                         <form onSubmit={onSubmitSearch}>
                           <div className={css.searchGroupWrap}>
                             <SearchField
@@ -491,6 +501,7 @@ PluginFindRecordModal.propTypes = {
   setSegment: PropTypes.func.isRequired,
   source: PropTypes.object,
   visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
+  config: CONFIG_TYPES,
 };
 
 PluginFindRecordModal.defaultProps = {
@@ -505,6 +516,9 @@ PluginFindRecordModal.defaultProps = {
   resultsFormatter: {},
   searchIndexes: [],
   segment: 'instances',
+  config: {
+    availableSegments: [],
+  },
 };
 
 export default injectIntl(PluginFindRecordModal);

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ of the Module Developer's Guide.
 | `isMultiSelect` | boolean | Flag to control if user can select several instances, default is `false` | No |
 | `selectInstance` | function | Callback with selected array of instances | No |
 | `renderNewBtn` | function | Render function for button `New` | No |
+| `config` | object | Allows to pass some options to the plugin components | No |
+
+## Config
+
+| Name | Type | Description | Required |
+--- | --- | --- | --- |
+| `availableSegments` | array of objects | Object should contain `name` field, which represent what exact section will be rendered. Possible variants of segments: `instances`, `holdings`, `items`. All uniq passed segments will be rendered. If nothing passed, all sections will be rendered. | No |
 
 This is a [Stripes](https://github.com/folio-org/stripes-core/) UI module to display, filter and select Inventory instance(s).
 

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -1,12 +1,24 @@
 import React from 'react';
 
 jest.mock('@folio/stripes/components', () => ({
-  Button: jest.fn(({ children }) => (
-    <button data-test-button type="button">
+  Button: jest.fn(({
+    children,
+    onClick,
+  }) => (
+    <button
+      data-test-button
+      type="button"
+      onClick={onClick}
+    >
       <span>
         {children}
       </span>
     </button>
+  )),
+  ButtonGroup: jest.fn(({ children }) => (
+    <div data-testid="buttonGroup">
+      {children}
+    </div>
   )),
   Checkbox: jest.fn(({
     checked,
@@ -196,7 +208,7 @@ jest.mock('@folio/stripes/components', () => ({
     readOnly,
     component = <input type="text" />,
     warningElement,
-    errorElement
+    errorElement,
   }) => (
     <div>
       {label && (


### PR DESCRIPTION
## Purpose
According to requirements for title-level requests feature, we need this plugin but with only `instances` segment.

## Approach
We added posibility to pass `config` into plugin, which can contain `availableSections` key, that represent sections to render. All uniq and valid sections from `availableSections` will be rendered. First passed section will set as active on first render. `availableSections` and  `config` is not required props. If nothing will passed, all three tabs will be rendered by default. This way we will not break anything, and no changes needed in other places where plugin used.
The new logic of the `FilterNavigation` component is fully covered by Jest/RTL tests.
Also we added information about new props into `README.md`.

## Refs
https://issues.folio.org/browse/UIPFI-91