### PR TITLE
UIPFI-95: Only fetch reference data when plugin is opened.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.2.0 IN PROGRESS
 
+* Only fetch reference data when plugin is opened. Fixes UIPFI-95.
+
 ## [6.1.4](https://github.com/folio-org/ui-plugin-find-instance/tree/v6.1.4) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v6.1.3...v6.1.4)
 

--- a/InstanceSearch/InstanceSearch.js
+++ b/InstanceSearch/InstanceSearch.js
@@ -10,7 +10,6 @@ import {
 
 import FindInstanceContainer from './FindInstanceContainer';
 
-import DataProvider from '../Imports/imports/DataProvider';
 import DataContext from '../Imports/imports/DataContext';
 import { getFilterConfig } from '../Imports/imports/filterConfig';
 import useInstancesQuery from '../hooks/useInstancesQuery';
@@ -45,34 +44,32 @@ const InstanceSearch = ({ selectInstance, isMultiSelect, renderNewBtn, onClose, 
   }, [isLoading, results, isMultiSelect, selectInstance]);
 
   return (
-    <DataProvider>
-      <PluginFindRecord
-        {...rest}
-        onClose={onClose}
-        selectRecordsCb={list => setInstances(list)}
-      >
-        {(modalProps) => (
-          <DataContext.Consumer>
-            {data => (
-              <FindInstanceContainer>
-                {(viewProps) => (
-                  <PluginFindRecordModal
-                    {...viewProps}
-                    {...modalProps}
-                    isMultiSelect={isMultiSelect}
-                    renderNewBtn={renderNewBtn}
-                    renderFilters={renderer({ ...data, query })}
-                    segment={segment}
-                    setSegment={setSegment}
-                    searchIndexes={indexes}
-                  />
-                )}
-              </FindInstanceContainer>
-            )}
-          </DataContext.Consumer>
-        )}
-      </PluginFindRecord>
-    </DataProvider>
+    <PluginFindRecord
+      {...rest}
+      onClose={onClose}
+      selectRecordsCb={list => setInstances(list)}
+    >
+      {(modalProps) => (
+        <DataContext.Consumer>
+          {data => (
+            <FindInstanceContainer>
+              {(viewProps) => (
+                <PluginFindRecordModal
+                  {...viewProps}
+                  {...modalProps}
+                  isMultiSelect={isMultiSelect}
+                  renderNewBtn={renderNewBtn}
+                  renderFilters={renderer({ ...data, query })}
+                  segment={segment}
+                  setSegment={setSegment}
+                  searchIndexes={indexes}
+                />
+              )}
+            </FindInstanceContainer>
+          )}
+        </DataContext.Consumer>
+      )}
+    </PluginFindRecord>
   );
 };
 

--- a/PluginFindRecord/PluginFindRecord.js
+++ b/PluginFindRecord/PluginFindRecord.js
@@ -8,6 +8,8 @@ import {
   Icon,
 } from '@folio/stripes/components';
 
+import DataProvider from '../Imports/imports/DataProvider';
+
 import css from './PluginFindRecord.css';
 
 const triggerId = 'find-instance-trigger';
@@ -85,11 +87,18 @@ class PluginFindRecord extends React.Component {
     return (
       <div className={this.getStyle()}>
         {withTrigger && this.renderTriggerButton()}
-        {this.state.openModal && children({
-          onSaveMultiple: this.passRecordsOut,
-          onSelectRow: this.passRecordOut,
-          closeModal: this.closeModal,
-        })}
+        {
+          this.state.openModal &&
+          <DataProvider>
+            {
+              children({
+                onSaveMultiple: this.passRecordsOut,
+                onSelectRow: this.passRecordOut,
+                closeModal: this.closeModal,
+              })
+            }
+          </DataProvider>
+        }
       </div>
     );
   }


### PR DESCRIPTION
Only fetch reference data when the plugin is actually opened.

There are some situations where the plugin instance is used multiple times on the same screen (for example in ui-inventory when multiple child or parent instances are present). This was causing an issue because the reference data was fetched once per each instance.

This PR moved the `DataProvider` around so it's only initialized when the plugin is actually opened.
 
https://issues.folio.org/browse/UIPFI-95

