### PR TITLE
UIPFI-96 Fix search of existing instance when moving holdings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Only fetch reference data when plugin is opened. Fixes UIPFI-95.
 * Add posibility to change visible filter fragments. Refs UIPFI-91.
+* Fix search of existing instance when moving holdings records. Fixes UIPFI-96.
 
 ## [6.1.4](https://github.com/folio-org/ui-plugin-find-instance/tree/v6.1.4) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v6.1.3...v6.1.4)

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -67,8 +67,8 @@ const contributorsFormatter = (r, contributorTypes) => {
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const { indexes, sortMap, filters } = getFilterConfig(queryParams.segment);
   const query = { ...resourceData.query };
-  const queryIndex = queryParams?.qindex ?? 'all';
-  const queryValue = get(queryParams, 'query', '');
+  const queryIndex = get(props, 'resources.query.qindex', 'all');
+  const queryValue = get(props, 'resources.query.query', '');
   let queryTemplate = getQueryTemplate(queryIndex, indexes);
 
   if (queryIndex.match(/isbn|issn/)) {

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -67,8 +67,8 @@ const contributorsFormatter = (r, contributorTypes) => {
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const { indexes, sortMap, filters } = getFilterConfig(queryParams.segment);
   const query = { ...resourceData.query };
-  const queryIndex = get(props, 'resources.query.qindex', 'all');
-  const queryValue = get(props, 'resources.query.query', '');
+  const queryIndex = props?.resources?.query?.qindex ?? 'all';
+  const queryValue = props?.resources?.query?.query ?? '';
   let queryTemplate = getQueryTemplate(queryIndex, indexes);
 
   if (queryIndex.match(/isbn|issn/)) {


### PR DESCRIPTION
Fix search of existing instance when moving holdings records between instances.

Previously, `queryIndex` and `queryValue` were taken from `queryParams` parameter passed to `buildQuery` function. The problem is that values for `queryParams`, according to the Stripes Connect [readme.md](https://github.com/folio-org/stripes-connect/blob/master/doc/api.md#functional-paths-and-parameters), are taken from "UI URL's query parameters". 

My guess is that since it's a modal window and UI URL isn't involved here, we get `{}` as a value. That resulted in default values for `queryIndex` and `queryValue` which is why it didn't search properly by any index except `Keyword` one. 

The solution was to use `props` parameter instead, which "contains redundant copies of much of the rest of the information passed in", as stated, again, in the Stripes Connect readme.

Issue: [UIPFI-96](https://issues.folio.org/browse/UIPFI-96)