### PR TITLE
UIPFI-99: Adjust queryIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Only fetch reference data when plugin is opened. Fixes UIPFI-95.
 * Add posibility to change visible filter fragments. Refs UIPFI-91.
 * Fix search of existing instance when moving holdings records. Fixes UIPFI-96.
+* Adjust `queryIndex`. Fixes UIPFI-99.
 
 ## [6.1.4](https://github.com/folio-org/ui-plugin-find-instance/tree/v6.1.4) (2022-02-24)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v6.1.3...v6.1.4)

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -67,7 +67,7 @@ const contributorsFormatter = (r, contributorTypes) => {
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const { indexes, sortMap, filters } = getFilterConfig(queryParams.segment);
   const query = { ...resourceData.query };
-  const queryIndex = props?.resources?.query?.qindex ?? 'all';
+  const queryIndex = props?.resources?.query?.qindex || 'all';
   const queryValue = props?.resources?.query?.query ?? '';
   let queryTemplate = getQueryTemplate(queryIndex, indexes);
 


### PR DESCRIPTION
The previous implementation was returning an empty string `''` which did not default to `all` causing issues when the search was performed. 

https://issues.folio.org/browse/UIPFI-99

This PR changes `??` to `||` to make sure `all` is set correctly.