### PR TITLE
UIPFI-111: Fix segment when switching between filter tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.4.0 IN PROGRESS
 
+* Fix segment when switching between filter tabs. Fixes UIIN-2258
+
 ## [6.3.0](https://github.com/folio-org/ui-plugin-find-instance/tree/v6.3.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v6.2.0...v6.3.0)
 

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -65,7 +65,7 @@ const contributorsFormatter = (r, contributorTypes) => {
 
 
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
-  const { indexes, sortMap, filters } = getFilterConfig(queryParams.segment);
+  const { indexes, sortMap, filters } = getFilterConfig(props.segment);
   const query = { ...resourceData.query };
   const queryIndex = props?.resources?.query?.qindex || 'all';
   const queryValue = props?.resources?.query?.query ?? '';
@@ -172,6 +172,7 @@ class FindInstanceContainer extends React.Component {
 
     setFilterValues(locations, 'location', 'name', 'id');
     setFilterValues(instanceTypes, 'resource', 'name', 'id');
+
     this.source.update(this.props);
   }
 

--- a/InstanceSearch/InstanceSearch.js
+++ b/InstanceSearch/InstanceSearch.js
@@ -61,7 +61,7 @@ const InstanceSearch = ({
       {(modalProps) => (
         <DataContext.Consumer>
           {data => (
-            <FindInstanceContainer>
+            <FindInstanceContainer segment={segment}>
               {(viewProps) => (
                 <PluginFindRecordModal
                   {...viewProps}


### PR DESCRIPTION
The segment was previously `undefined` when switching between tabs. This was happening because the state is kept in `useState` instead of the query param. 

Passing it as a prop to `FindInstanceContainer` and referencing it via `props` in `buildQuery` made it work again.

https://issues.folio.org/browse/UIPFI-111