### PR TITLE
UIPFI-114 clean up direct dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix segment when switching between filter tabs. Fixes UIIN-2258
 * Bump search interface to 1.0. Fixes UIPFI-112
 * Bump stripes to 8.0.0 for Orchid/2023-R1. Refs UIPFI-113.
+* Dependency clean up (move select deps out to peer, dev). Refs UIPFI-114.
 
 ## [6.3.0](https://github.com/folio-org/ui-plugin-find-instance/tree/v6.3.0) (2022-10-24)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v6.2.0...v6.3.0)

--- a/package.json
+++ b/package.json
@@ -69,20 +69,20 @@
     "react-dom": "^17.0.2",
     "react-intl": "^5.7.0",
     "react-router-dom": "^5.2.0",
-    "regenerator-runtime": "^0.13.3"
+    "regenerator-runtime": "^0.13.3",
+    "sinon": "^9.0.2"
   },
   "dependencies": {
     "classnames": "^2.2.6",
     "lodash": "^4.17.11",
-    "moment": "^2.29.1",
-    "prop-types": "^15.6.0",
-    "react-query": "^3.6.0",
-    "sinon": "^9.0.2"
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^8.0.0",
+    "moment": "^2.29.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-intl": "^5.7.0"
+    "react-intl": "^5.7.0",
+    "react-query": "^3.6.0"
   }
 }


### PR DESCRIPTION
Some direct-deps should be moved out to dev or peer.

Refs [UIPFI-114](https://issues.folio.org/browse/UIPFI-114)
