### PR TITLE
UIPFI-130 Allow users to select Shared instances

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,13 +10,13 @@
       "files": ["*test.js", "test/**"],
       "rules": {
         "react/prop-types": "off",
-        "import/prefer-default-export": "off"
       }
     },
     {
       "files": [ "**"],
       "rules": {
-        "react-hooks/exhaustive-deps": "off"
+        "react-hooks/exhaustive-deps": "off",
+        "import/prefer-default-export": "off"
       }
     }
   ],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add Shared icon to inventory instance results. Refs UIPFI-123.
 * Add Shared filter. Refs UIPFI-119.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIPFI-126.
+* Allow users to select Shared instances. Refs UIPFI-130.
 
 ## [6.5.0](https://github.com/folio-org/ui-plugin-find-instance/tree/v6.4.0) (2023-03-20)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v6.4.0...v6.5.0)

--- a/InstanceSearch/InstanceSearch.js
+++ b/InstanceSearch/InstanceSearch.js
@@ -36,8 +36,7 @@ const InstanceSearch = ({
     renderer,
   } = getFilterConfig(segment);
 
-  const instantceIds = instances.filter(inst => inst).map(inst => inst.id);
-  const results = useInstancesQuery(instantceIds);
+  const results = useInstancesQuery(instances);
   const isLoading = results.some(result => result.isLoading);
 
   useEffect(() => {

--- a/constants/headers.js
+++ b/constants/headers.js
@@ -1,0 +1,1 @@
+export const OKAPI_TENANT_HEADER = 'X-Okapi-Tenant';

--- a/constants/index.js
+++ b/constants/index.js
@@ -1,0 +1,1 @@
+export * from './headers';

--- a/hooks/useInstancesQuery.test.js
+++ b/hooks/useInstancesQuery.test.js
@@ -37,7 +37,7 @@ describe('useInstancesQuery', () => {
   });
 
   it('fetches instances', async () => {
-    const { result } = renderHook(() => useInstancesQuery([instance.id]), { wrapper });
+    const { result } = renderHook(() => useInstancesQuery([instance]), { wrapper });
     await waitFor(() => expect(result.current[0].data.id).toEqual(instance.id));
   });
 });


### PR DESCRIPTION
## Description
Allow users to select Shared instances. Use correct `tenantId` for different selected Instance records

## Screenshots

https://github.com/folio-org/ui-plugin-find-instance/assets/19309423/f07bbf19-d2e9-4550-a6e6-88ba648bcff2



## Issues
[UIPFI-130](https://issues.folio.org/browse/UIPFI-130)