### PR TITLE
UIPFI-133 Staff suppress facet - default option "No" selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Remove bigtest tests. Refs UIPFI-134.
 * Cover <TagsFilter> component with tests. Refs UIPFI-127.
 * Add a new search option for instances called `LCCN normalization`. Refs UIPFI-135.
+* Staff suppress facet - default option "No" selected. Refs UIPFI-133.
 
 ## [7.0.4](https://github.com/folio-org/ui-plugin-find-instance/tree/v7.0.4) (2024-02-01)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.0.3...v7.0.4)

--- a/Imports/imports/InstanceFilters/InstanceFilters.js
+++ b/Imports/imports/InstanceFilters/InstanceFilters.js
@@ -109,17 +109,17 @@ const InstanceFilters = ({
     },
   ];
 
-  const clearStaffSuppressStorageFlag = useCallback(() => {
+  const setStaffSuppressStorageFlag = useCallback(() => {
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, true);
   }, []);
 
   const handleChange = useCallback((...args) => {
-    clearStaffSuppressStorageFlag();
+    setStaffSuppressStorageFlag();
     onChange(...args);
   }, [onChange]);
 
   const handleClearFilter = useCallback((name) => {
-    clearStaffSuppressStorageFlag();
+    setStaffSuppressStorageFlag();
     onClear(name);
   }, [onClear]);
 

--- a/Imports/imports/InstanceFilters/InstanceFilters.js
+++ b/Imports/imports/InstanceFilters/InstanceFilters.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -27,6 +27,7 @@ import TagsFilter from '../TagsFilter';
 import SharedFilter from '../SharedFilter';
 import TenantIdFilter from '../TenantIdFilter';
 import { LocationFilter } from '../LocationFilter';
+import { USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY } from '../constants';
 
 const DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -108,6 +109,22 @@ const InstanceFilters = ({
     },
   ];
 
+  const clearStaffSuppressStorageFlag = useCallback(() => {
+    sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, true);
+  }, []);
+
+  const handleChange = useCallback((...args) => {
+    clearStaffSuppressStorageFlag();
+    onChange(...args);
+  }, [onChange]);
+
+  const handleClearFilter = useCallback((name) => {
+    clearStaffSuppressStorageFlag();
+    onClear(name);
+  }, [onClear]);
+
+  const isStaffSuppressFilterAvailable = stripes.hasPerm('ui-inventory.instance.view-staff-suppressed-records');
+
   return (
     <>
       {isUserInMemberTenant && (
@@ -136,7 +153,7 @@ const InstanceFilters = ({
         onClear={onClear}
       />
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.instances.language" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.instances.language' })}
         id="language"
         name="language"
         separator={false}
@@ -153,7 +170,7 @@ const InstanceFilters = ({
         />
       </Accordion>
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.instances.resourceType" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.instances.resourceType' })}
         id="resource"
         name="resource"
         closedByDefault
@@ -170,7 +187,7 @@ const InstanceFilters = ({
         />
       </Accordion>
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.instanceFormat" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.instanceFormat' })}
         id="format"
         name="format"
         closedByDefault
@@ -187,7 +204,7 @@ const InstanceFilters = ({
         />
       </Accordion>
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.modeOfIssuance" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.modeOfIssuance' })}
         id="mode"
         name="mode"
         closedByDefault
@@ -204,7 +221,7 @@ const InstanceFilters = ({
         />
       </Accordion>
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.natureOfContentTerms" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.natureOfContentTerms' })}
         id="natureOfContent"
         name="natureOfContent"
         closedByDefault
@@ -220,25 +237,27 @@ const InstanceFilters = ({
           onChange={onChange}
         />
       </Accordion>
-      <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.staffSuppress" />}
-        id="staffSuppress"
-        name="staffSuppress"
-        closedByDefault
-        header={FilterAccordionHeader}
-        displayClearButton={staffSuppress.length > 0}
-        onClearFilter={() => onClear('staffSuppress')}
-      >
-        <CheckboxFilter
-          data-test-filter-instance-staff-suppress
+      {isStaffSuppressFilterAvailable && (
+        <Accordion
+          label={intl.formatMessage({ id: 'ui-plugin-find-instance.staffSuppress' })}
+          id="staffSuppress"
           name="staffSuppress"
-          dataOptions={suppressedOptions}
-          selectedValues={staffSuppress}
-          onChange={onChange}
-        />
-      </Accordion>
+          closedByDefault
+          header={FilterAccordionHeader}
+          displayClearButton={staffSuppress.length > 0}
+          onClearFilter={() => handleClearFilter('staffSuppress')}
+        >
+          <CheckboxFilter
+            data-test-filter-instance-staff-suppress
+            name="staffSuppress"
+            dataOptions={suppressedOptions}
+            selectedValues={staffSuppress}
+            onChange={handleChange}
+          />
+        </Accordion>
+      )}
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.discoverySuppress" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.discoverySuppress' })}
         id="discoverySuppress"
         name="discoverySuppress"
         closedByDefault
@@ -255,7 +274,7 @@ const InstanceFilters = ({
         />
       </Accordion>
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.createdDate" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.createdDate' })}
         id="createdDate"
         name="createdDate"
         closedByDefault
@@ -272,7 +291,7 @@ const InstanceFilters = ({
         />
       </Accordion>
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.updatedDate" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.updatedDate' })}
         id="updatedDate"
         name="updatedDate"
         closedByDefault
@@ -289,7 +308,7 @@ const InstanceFilters = ({
         />
       </Accordion>
       <Accordion
-        label={<FormattedMessage id="ui-plugin-find-instance.source" />}
+        label={intl.formatMessage({ id: 'ui-plugin-find-instance.source' })}
         id="source"
         name="source"
         closedByDefault

--- a/Imports/imports/InstanceFilters/InstanceFilters.test.js
+++ b/Imports/imports/InstanceFilters/InstanceFilters.test.js
@@ -6,8 +6,16 @@ import {
 
 import InstanceFilters from './InstanceFilters';
 import Harness from '../../../test/jest/helpers/harness';
+import { USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY } from '../constants';
 
 jest.mock('../TagsFilter', () => jest.fn().mockReturnValue('TagsFilter'));
+jest.mock('@folio/stripes/smart-components', () => ({
+  ...jest.requireActual('@folio/stripes/smart-components'),
+  CheckboxFilter: ({ name, onChange }) => ((
+    <button type="button" onClick={() => onChange()}>change facet {name}</button>
+  )),
+}));
+jest.unmock('@folio/stripes/components');
 
 const activeFilters = {
   shared: ['true'],
@@ -84,75 +92,75 @@ describe('InstanceFilters', () => {
     });
 
     it('Should Clear selected filters for shared', () => {
-      const clearShared = document.querySelector('[data-testid="clear-shared"]');
+      const clearShared = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.filters.shared"' });
       fireEvent.click(clearShared);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for effective Location', () => {
-      const cleareffectiveLocation = document.querySelector('[data-testid="clear-effectiveLocation"]');
+      const cleareffectiveLocation = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.filters.effectiveLocation"' });
       fireEvent.click(cleareffectiveLocation);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for language', () => {
-      const clearlanguage = document.querySelector('[data-testid="clear-language"]');
+      const clearlanguage = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.instances.language"' });
       fireEvent.click(clearlanguage);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for resource', () => {
-      const clearresource = document.querySelector('[data-testid="clear-resource"]');
+      const clearresource = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.instances.resourceType"' });
       fireEvent.click(clearresource);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for format', () => {
-      const clearformat = document.querySelector('[data-testid="clear-format"]');
+      const clearformat = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.instanceFormat"' });
       fireEvent.click(clearformat);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for mode', () => {
-      const clearmode = document.querySelector('[data-testid="clear-mode"]');
+      const clearmode = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.modeOfIssuance"' });
       fireEvent.click(clearmode);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for natureOfContent', () => {
-      const clearnatureOfContent = document.querySelector('[data-testid="clear-natureOfContent"]');
+      const clearnatureOfContent = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.natureOfContentTerms"' });
       fireEvent.click(clearnatureOfContent);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for staffSuppress', () => {
-      const clearstaffSuppress = document.querySelector('[data-testid="clear-staffSuppress"]');
+      const clearstaffSuppress = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.staffSuppress"' });
       fireEvent.click(clearstaffSuppress);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for discoverySuppress', () => {
-      const cleardiscoverySuppress = document.querySelector('[data-testid="clear-discoverySuppress"]');
+      const cleardiscoverySuppress = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.discoverySuppress"' });
       fireEvent.click(cleardiscoverySuppress);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for createdDate', () => {
-      const clearcreatedDate = document.querySelector('[data-testid="clear-createdDate"]');
+      const clearcreatedDate = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.createdDate"' });
       fireEvent.click(clearcreatedDate);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for updatedDate', () => {
-      const clearupdatedDate = document.querySelector('[data-testid="clear-updatedDate"]');
+      const clearupdatedDate = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.updatedDate"' });
       fireEvent.click(clearupdatedDate);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('Should Clear selected filters for source', () => {
-      const clearsource = document.querySelector('[data-testid="clear-source"]');
+      const clearsource = screen.getByRole('button', { name: 'Clear selected filters for "ui-plugin-find-instance.source"' });
       fireEvent.click(clearsource);
-      expect(mockClear).toBeCalled();
+      expect(mockClear).toHaveBeenCalled();
     });
 
     it('should render Shared filter', () => {
@@ -160,18 +168,23 @@ describe('InstanceFilters', () => {
     });
   });
 
-  describe('when filters are empty', () => {
+  describe('when user selects staff suppress options', () => {
+    const mockSetItem = jest.fn();
     beforeEach(() => {
-      renderInstanceFilters({
-        activeFilters: {},
-      });
+      global.Storage.prototype.setItem = mockSetItem;
     });
 
-    it('should disable clear buttons', () => {
-      const clearButtons = screen.getAllByRole('button', { name: 'Clear' });
-      clearButtons.forEach((button) => {
-        expect(button).toBeDisabled();
-      });
+    afterEach(() => {
+      global.Storage.prototype.setItem.mockReset();
+    });
+
+    it('should set a flag that user selected some option', async () => {
+      renderInstanceFilters();
+      const staffSuppressFacet = screen.queryByRole('button', { name: 'ui-plugin-find-instance.staffSuppress filter list' });
+      await fireEvent.click(staffSuppressFacet);
+      await fireEvent.click(screen.getByText('change facet staffSuppress'));
+
+      expect(mockSetItem).toHaveBeenCalledWith(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, true);
     });
   });
 });

--- a/Imports/imports/SharedFilter/SharedFilter.js
+++ b/Imports/imports/SharedFilter/SharedFilter.js
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 import { useQuery } from 'react-query';
 
 import {
@@ -23,6 +26,7 @@ const SharedFilter = ({
   onClear,
   onChange,
 }) => {
+  const intl = useIntl();
   const ky = useOkapiKy();
   const namespace = useNamespace();
 
@@ -45,7 +49,7 @@ const SharedFilter = ({
 
   return (
     <Accordion
-      label={<FormattedMessage id="ui-plugin-find-instance.filters.shared" />}
+      label={intl.formatMessage({ id: 'ui-plugin-find-instance.filters.shared' })}
       id="shared"
       name="shared"
       separator={false}

--- a/Imports/imports/TenantIdFilter/TenantIdFilter.js
+++ b/Imports/imports/TenantIdFilter/TenantIdFilter.js
@@ -1,8 +1,5 @@
 import { useContext } from 'react';
-import {
-  FormattedMessage,
-  useIntl,
-} from 'react-intl';
+import { useIntl } from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {

--- a/Imports/imports/TenantIdFilter/TenantIdFilter.js
+++ b/Imports/imports/TenantIdFilter/TenantIdFilter.js
@@ -1,5 +1,8 @@
 import { useContext } from 'react';
-import { FormattedMessage } from 'react-intl';
+import {
+  FormattedMessage,
+  useIntl,
+} from 'react-intl';
 import PropTypes from 'prop-types';
 
 import {
@@ -21,6 +24,7 @@ const TenantIdFilter = ({
   onClear,
   onChange,
 }) => {
+  const intl = useIntl();
   const { consortiaTenants } = useContext(DataContext);
 
   const dataOptions = consortiaTenants?.map(({ id, name }) => ({
@@ -34,7 +38,7 @@ const TenantIdFilter = ({
     <Accordion
       id={name}
       name={name}
-      label={<FormattedMessage id="ui-plugin-find-instance.filters.tenantId" />}
+      label={intl.formatMessage({ id: 'ui-plugin-find-instance.filters.tenantId' })}
       closedByDefault
       separator={false}
       header={FilterAccordionHeader}

--- a/Imports/imports/constants.js
+++ b/Imports/imports/constants.js
@@ -43,3 +43,5 @@ export const CONFIG_TYPES = PropTypes.shape({
 });
 
 export const DEFAULT_FILTERS_NUMBER = 6;
+
+export const USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY = 'folio_find-instance_user_touched_staff_suppress';

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -189,7 +189,7 @@ class FindInstanceContainer extends React.Component {
       query: '',
       filters: staffSuppressFalse,
     });
-    window.addEventListener('beforeunload', this.handleBeforeUnload);
+    window.addEventListener('beforeunload', this.clearStaffSuppressStorageFlag);
   }
 
   componentDidUpdate() {
@@ -204,11 +204,11 @@ class FindInstanceContainer extends React.Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('beforeunload', this.handleBeforeUnload);
-    sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
+    window.removeEventListener('beforeunload', this.clearStaffSuppressStorageFlag);
+    this.clearStaffSuppressStorageFlag();
   }
 
-  handleBeforeUnload = () => {
+  clearStaffSuppressStorageFlag = () => {
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
   }
 

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -19,7 +19,10 @@ import {
   getQueryTemplate,
   getIsbnIssnTemplate,
 } from '../Imports/imports/utils';
-import { CQL_FIND_ALL } from '../Imports/imports/constants';
+import {
+  CQL_FIND_ALL,
+  USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
+} from '../Imports/imports/constants';
 
 import css from './FindInstanceContainer.css';
 
@@ -39,6 +42,7 @@ const columnMapping = {
 };
 
 const idPrefix = 'uiPluginFindInstance-';
+const staffSuppressFalse = 'staffSuppress.false';
 const modalLabel = <FormattedMessage id="ui-plugin-find-instance.modal.title" />;
 const filterConfig = getFilterConfig().filters;
 
@@ -67,6 +71,15 @@ const contributorsFormatter = (r, contributorTypes) => {
   return formatted;
 };
 
+const applyDefaultStaffSuppressFilter = (query) => {
+  const isUserTouchedStaffSuppress = JSON.parse(sessionStorage.getItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY));
+
+  if (!query.query && query.filters === staffSuppressFalse && !isUserTouchedStaffSuppress) {
+    // if query is empty and the only filter value is staffSuppress.false and search was not initiated by user action
+    // then we need to clear the query.filters here to not automatically search when Inventory search is opened
+    query.filters = undefined;
+  }
+};
 
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const { indexes, sortMap, filters } = getFilterConfig(props.segment);
@@ -87,6 +100,8 @@ export function buildQuery(queryParams, pathComponents, resourceData, logger, pr
     // Default sort for filtering/searching instances/holdings/items should be by title (UIIN-1046)
     query.sort = 'title';
   }
+
+  applyDefaultStaffSuppressFilter(query);
 
   resourceData.query = { ...query, qindex: '' };
 
@@ -110,7 +125,7 @@ class FindInstanceContainer extends React.Component {
     query: {
       initialValue: {
         query: '',
-        filters: '',
+        filters: staffSuppressFalse,
       },
     },
     records: {
@@ -169,7 +184,12 @@ class FindInstanceContainer extends React.Component {
 
   componentDidMount() {
     this.source = new StripesConnectedSource(this.props, this.logger);
-    this.props.mutator.query.replace('');
+    this.props.mutator.query.replace({
+      qindex: this.state.qindex,
+      query: '',
+      filters: staffSuppressFalse,
+    });
+    window.addEventListener('beforeunload', this.handleBeforeUnload);
   }
 
   componentDidUpdate() {
@@ -181,6 +201,15 @@ class FindInstanceContainer extends React.Component {
     setFilterValues(instanceTypes, 'resource', 'name', 'id');
 
     this.source.update(this.props);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('beforeunload', this.handleBeforeUnload);
+    sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
+  }
+
+  handleBeforeUnload = () => {
+    sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
   }
 
   fetchMore = () => {

--- a/InstanceSearch/InstanceSearch.js
+++ b/InstanceSearch/InstanceSearch.js
@@ -17,7 +17,10 @@ import DataContext from '../Imports/imports/DataContext';
 import { getFilterConfig } from '../Imports/imports/filterConfig';
 import { useInstancesQuery } from '../hooks';
 
-import { CONFIG_TYPES } from '../Imports/imports/constants';
+import {
+  CONFIG_TYPES,
+  USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
+} from '../Imports/imports/constants';
 import { parseHttpError } from '../utils';
 
 const query = {
@@ -44,6 +47,10 @@ const InstanceSearch = ({
   } = getFilterConfig(segment);
 
   const { isLoading, isError, error = {}, data = {} } = useInstancesQuery(instances);
+
+  useEffect(() => {
+    sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
+  }, [segment]);
 
   useEffect(() => {
     if (!isLoading && !isError && data.instances?.length) {

--- a/PluginFindRecord/PluginFindRecordModal.js
+++ b/PluginFindRecord/PluginFindRecordModal.js
@@ -33,7 +33,10 @@ import Filters from './Filters';
 import css from './PluginFindRecordModal.css';
 import FilterNavigation from '../Imports/imports/FilterNavigation';
 
-import { CONFIG_TYPES } from '../Imports/imports/constants';
+import {
+  CONFIG_TYPES,
+  USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
+} from '../Imports/imports/constants';
 
 const RESULTS_HEADER = <FormattedMessage id="ui-plugin-find-instance.resultsHeader" />;
 
@@ -195,6 +198,11 @@ class PluginFindRecordModal extends React.Component {
     }
 
     return nextState;
+  }
+
+  handleResetAll = (cb) => () => {
+    sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
+    cb();
   }
 
   render() {
@@ -379,7 +387,7 @@ class PluginFindRecordModal extends React.Component {
                           availableSegments={availableSegments}
                           segment={segment}
                           setSegment={setSegment}
-                          reset={resetAll}
+                          reset={this.handleResetAll(resetAll)}
                         />
                         <form onSubmit={onSubmitSearch}>
                           <div className={css.searchGroupWrap}>
@@ -413,7 +421,7 @@ class PluginFindRecordModal extends React.Component {
                               disabled={disableReset()}
                               fullWidth
                               id="clickable-reset-all"
-                              onClick={resetAll}
+                              onClick={this.handleResetAll(resetAll)}
                             >
                               <Icon icon="times-circle-solid">
                                 <FormattedMessage id="stripes-smart-components.resetAll" />

--- a/PluginFindRecord/PluginFindRecordModal.js
+++ b/PluginFindRecord/PluginFindRecordModal.js
@@ -334,6 +334,9 @@ class PluginFindRecordModal extends React.Component {
             initialSearch={initialSearch}
             initialSearchState={{ qindex: '', query: '' }}
             initialSortState={{ sort: 'title' }}
+            initialFilterState={{
+              staffSuppress: ['false'],
+            }}
             onComponentWillUnmount={onComponentWillUnmount}
             queryGetter={queryGetter}
             querySetter={querySetter}

--- a/test/jest/__mock__/stripesComponents.mock.js
+++ b/test/jest/__mock__/stripesComponents.mock.js
@@ -145,7 +145,7 @@ jest.mock('@folio/stripes/components', () => ({
       </div>
     );
   }),
-  languageOptions: jest.fn(() => <div>languageOptions</div>),
+  languageOptions: jest.fn(() => []),
   PaneMenu: jest.fn(({ children }) => <div>{children}</div>),
   Paneset: jest.fn(({ children }) => <div>{children}</div>),
   SearchField: jest.fn(({


### PR DESCRIPTION
## Description
Staff suppress facet - default option "No" selected
Similar approach to Inventory - set default `resources.query` properties and track user interaction with staff suppress filter with session storage flag.

## Screenshots

https://github.com/folio-org/ui-plugin-find-instance/assets/19309423/7f8ec6c6-74da-479b-a003-ebeb42b08baf


## Issues
[UIPFI-133](https://folio-org.atlassian.net/browse/UIPFI-133)