### PR TITLE
UIPFI-133 use nextState in queryStateReducer when changeType is reset.all (follow-up)

### DIFF
--- a/PluginFindRecord/PluginFindRecordModal.js
+++ b/PluginFindRecord/PluginFindRecordModal.js
@@ -175,6 +175,10 @@ class PluginFindRecordModal extends React.Component {
   are.
   */
   queryStateReducer = (state, nextState) => {
+    if (nextState.changeType === 'reset.all') {
+      return nextState;
+    }
+
     /* nextState.filterChanged only tells us that next filter state is different from initial filter state so we can enable/disable resetAll button etc
       we can't rely on nextState.filterChanged to check if some filter values changed because it's calculated by comparing full next state and default values.
       but we don't know the full next state until this function returns.


### PR DESCRIPTION
## Description
Don't combine current state and next state when `changeType` is `reset.all`. Next state has default values and should be applied without change

## Screenshots

https://github.com/folio-org/ui-plugin-find-instance/assets/19309423/2ed1b058-5ccb-4b75-baa1-48511174de40


## Issues
[UIPFI-133](https://folio-org.atlassian.net/browse/UIPFI-133)