### PR TITLE
UIPFI-147 Use `SearchAndSortQuery` `qindex` instead of what is stored in state.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-find-instance
 
+## [7.1.1] (IN PROGRESS)
+
+* Use `SearchAndSortQuery` `qindex` instead of what is stored in state. Fixes UIPFI-147.
+
 ## [7.1.0](https://github.com/folio-org/ui-plugin-find-instance/tree/v7.1.0) (2024-03-21)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.0.3...v7.1.0)
 

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -172,9 +172,6 @@ class FindInstanceContainer extends React.Component {
     super(props, context);
 
     this.state = {
-      // The qindex param holds the search index to use for a query,
-      // if multiple indices are in play
-      qindex: '',
       index: 0,
     };
 
@@ -185,7 +182,7 @@ class FindInstanceContainer extends React.Component {
   componentDidMount() {
     this.source = new StripesConnectedSource(this.props, this.logger);
     this.props.mutator.query.replace({
-      qindex: this.state.qindex,
+      qindex: '',
       query: '',
       filters: staffSuppressFalse,
     });
@@ -236,29 +233,19 @@ class FindInstanceContainer extends React.Component {
       mutator: { query, resultOffset },
     } = this.props;
 
-    const nsValuesWithIndex = {
-      ...nsValues,
-      qindex: this.state.qindex,
-    };
-
     if (resultOffset) {
       resultOffset.replace(0);
     }
 
     if (/reset/.test(state.changeType)) {
-      query.replace(nsValuesWithIndex);
+      query.replace(nsValues);
     } else {
-      query.update(nsValuesWithIndex);
+      query.update(nsValues);
     }
   }
 
   queryGetter = () => {
     return get(this.props.resources, 'query', {});
-  }
-
-  // Handler for a change of search index in PluginFindRecordModal's <SearchField> component
-  setSearchIndex = (e) => {
-    this.setState({ qindex: e.target.value });
   }
 
   render() {
@@ -308,7 +295,6 @@ class FindInstanceContainer extends React.Component {
       queryGetter: this.queryGetter,
       querySetter: this.querySetter,
       resultsFormatter,
-      setSearchIndex: this.setSearchIndex,
       source: this.source,
       visibleColumns,
       index: this.state.index,

--- a/InstanceSearch/FindInstanceContainer.test.js
+++ b/InstanceSearch/FindInstanceContainer.test.js
@@ -149,7 +149,7 @@ describe('FindInstanceContainer', () => {
     expect(defaultProps.mutator.query.replace).toHaveBeenCalledWith({ qindex: '' });
   });
 
-  describe.only('buildQuery', () => {
+  describe('buildQuery', () => {
     describe('when query is empty', () => {
       it('should return empty query parameters', () => {
         const queryParams = 'queryParams';

--- a/InstanceSearch/FindInstanceContainer.test.js
+++ b/InstanceSearch/FindInstanceContainer.test.js
@@ -91,9 +91,11 @@ const publishersData = {
 };
 const renderFindInstanceContainer = (prop) => render(
   <FindInstanceContainer {...prop}>
-    {({ data, onNeedMoreData, querySetter, resultsFormatter, setSearchIndex }) => {
+    {({ data, onNeedMoreData, querySetter, resultsFormatter }) => {
       const querySetterValues = {
-        nsValues: {},
+        nsValues: {
+          qindex: '',
+        },
         state: {
           changeType: 'update'
         }
@@ -108,7 +110,6 @@ const renderFindInstanceContainer = (prop) => render(
         resultsFormatter.title({ title: 'title' });
         resultsFormatter.contributors(contributorsData);
         resultsFormatter.publishers(publishersData);
-        setSearchIndex({ target: { value: 'isbn' } });
       };
       return (
         <div
@@ -146,7 +147,11 @@ describe('FindInstanceContainer', () => {
 
   it('query.replace function to be called when changeType value is reset', () => {
     fireEvent.click(screen.getByText('querySetterForReset'));
-    expect(defaultProps.mutator.query.replace).toHaveBeenCalledWith({ qindex: '' });
+    expect(defaultProps.mutator.query.replace).toHaveBeenCalledWith({
+      qindex: '',
+      query: '',
+      filters: 'staffSuppress.false',
+    });
   });
 
   describe('buildQuery', () => {

--- a/PluginFindRecord/PluginFindRecordModal.js
+++ b/PluginFindRecord/PluginFindRecordModal.js
@@ -237,7 +237,6 @@ class PluginFindRecordModal extends React.Component {
       renderNewBtn,
       resultsFormatter,
       searchIndexes,
-      setSearchIndex,
       segment,
       setSegment,
       source,
@@ -409,11 +408,13 @@ class PluginFindRecordModal extends React.Component {
                               data-test-plugin-search-input
                               marginBottom0
                               name="query"
+                              indexName="qindex"
                               onChange={getSearchHandlers().query}
                               onClear={getSearchHandlers().reset}
                               searchableIndexes={formattedSearchableIndexes}
-                              onChangeIndex={setSearchIndex}
+                              onChangeIndex={getSearchHandlers().query}
                               value={searchValue.query}
+                              selectedIndex={searchValue.qindex}
                             />
                             <Button
                               buttonStyle="primary"
@@ -524,7 +525,6 @@ PluginFindRecordModal.propTypes = {
   resultsFormatter: PropTypes.object,
   searchIndexes: PropTypes.arrayOf(PropTypes.object),
   segment: PropTypes.string,
-  setSearchIndex: PropTypes.func.isRequired,
   setSegment: PropTypes.func.isRequired,
   source: PropTypes.object,
   visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,


### PR DESCRIPTION
## Description
The plugin previously stored `qindex` in internal state which was not cleared when clicking "Reset all".
We don't need this separate state because `SearchAndSortQuery` already handles all other state parameters and it makes sense to delegate handling of `qindex` to it too

## Screenshot

https://github.com/folio-org/ui-plugin-find-instance/assets/19309423/13491711-abd6-40e3-a94f-8b17f4013594



## Issues
[UIPFI-147](https://folio-org.atlassian.net/browse/UIPFI-147)