### PR TITLE
UIPFI-146 Use consolidated locations endpoint to fetch all locations when in central tenant context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.2.0] IN PROGRESS
 
 * Add new Instance search option `Classification, normalized` for the `Instance` toggle. Refs UIPFI-149.
+* Use consolidated locations endpoint to fetch all locations when in central tenant context. Refs UIPFI-146.
 
 ## [7.1.1](https://github.com/folio-org/ui-plugin-find-instance/tree/v7.1.1) (2024-04-01)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.1.0...v7.1.1)

--- a/Imports/imports/DataProvider.js
+++ b/Imports/imports/DataProvider.js
@@ -1,5 +1,6 @@
 import keyBy from 'lodash/keyBy';
 import {
+  useEffect,
   useMemo,
 } from 'react';
 import PropTypes from 'prop-types';
@@ -21,6 +22,7 @@ import { isUserInConsortiumMode } from './utils';
 const DataProvider = ({
   children,
   resources,
+  mutator,
 }) => {
   const stripes = useStripes();
   const { manifest } = DataProvider;
@@ -31,6 +33,14 @@ const DataProvider = ({
   } = useConsortiaTenants();
 
   const tenantIds = consortiaTenants?.map(tenant => tenant.id);
+
+  useEffect(() => {
+    if (isUserInConsortiumMode(stripes)) {
+      return;
+    }
+
+    mutator.locations.GET({ tenant: stripes.okapi.tenant });
+  }, [stripes.okapi.tenant]);
 
   const {
     data: locationsOfAllTenants,
@@ -90,6 +100,7 @@ const DataProvider = ({
 
 DataProvider.propTypes = {
   resources: PropTypes.object.isRequired,
+  mutator: PropTypes.object.isRequired,
   children: PropTypes.object,
 };
 
@@ -112,6 +123,7 @@ DataProvider.manifest = {
       limit: (q, p, r, l, props) => props?.stripes?.config?.maxUnpagedResourceCount || 1000,
       query: 'cql.allRecords=1 sortby name',
     },
+    accumulate: true,
   },
   modesOfIssuance: {
     type: 'okapi',

--- a/Imports/imports/HoldingsFilters/HoldingsRecordFilters.test.js
+++ b/Imports/imports/HoldingsFilters/HoldingsRecordFilters.test.js
@@ -20,7 +20,7 @@ const activeFilters = {
 const data = {
   locations: [
     {
-      _tenantId: 'cs00000int_0001',
+      tenantId: 'cs00000int_0001',
       name: 'location1',
       id: 'locationid1'
     }

--- a/Imports/imports/InstanceFilters/InstanceFilters.test.js
+++ b/Imports/imports/InstanceFilters/InstanceFilters.test.js
@@ -36,7 +36,7 @@ const activeFilters = {
 const data = {
   locations: [
     {
-      _tenantId: 'cs00000int_0001',
+      tenantId: 'cs00000int_0001',
       name: 'location1',
       id: 'locationid1'
     }

--- a/Imports/imports/ItemFilters/ItemFilters.test.js
+++ b/Imports/imports/ItemFilters/ItemFilters.test.js
@@ -22,7 +22,7 @@ const activeFilters = {
 const data = {
   locations: [
     {
-      _tenantId: 'cs00000int_0001',
+      tenantId: 'cs00000int_0001',
       name: 'location1',
       id: 'locationid1'
     }

--- a/Imports/imports/LocationFilter/LocationFilter.js
+++ b/Imports/imports/LocationFilter/LocationFilter.js
@@ -50,9 +50,9 @@ export const LocationFilter = ({
 
   const getOptions = () => {
     if (isUserInConsortiumMode(stripes)) {
-      return uniqueLocations.map(({ name: locationName, id: locationId, _tenantId }) => {
+      return uniqueLocations.map(({ name: locationName, id: locationId, tenantId }) => {
         const isDuplicate = groupedLocations[locationName].length > 1;
-        const tenantName = groupedConsortiaTenants[_tenantId][0].name;
+        const tenantName = groupedConsortiaTenants[tenantId][0].name;
 
         return {
           label: isDuplicate ? `${locationName} (${tenantName})` : locationName,

--- a/Imports/imports/LocationFilter/LocationFilter.test.js
+++ b/Imports/imports/LocationFilter/LocationFilter.test.js
@@ -30,22 +30,22 @@ const locationsWithDuplicates = [
   {
     id: '53cf956f-c1df-410b-8bea-27f712cca7c0',
     name: 'Annex',
-    _tenantId: 'cs00000int_0001',
+    tenantId: 'cs00000int_0001',
   },
   {
     id: '53cf956f-c1df-410b-8bea-27f712cca7c0',
     name: 'Annex',
-    _tenantId: 'cs00000int',
+    tenantId: 'cs00000int',
   },
   {
     id: '184aae84-a5bf-4c6a-85ba-4a7c73026cd5',
     name: 'Online',
-    _tenantId: 'cs00000int_0003',
+    tenantId: 'cs00000int_0003',
   },
   {
     id: '8e9f7ced-d720-4cd4-b098-0f7c1f7c3ceb',
     name: 'Annex',
-    _tenantId: 'cs00000int_0005',
+    tenantId: 'cs00000int_0005',
   },
 ];
 

--- a/InstanceSearch/FindInstanceContainer.js
+++ b/InstanceSearch/FindInstanceContainer.js
@@ -148,12 +148,6 @@ class FindInstanceContainer extends React.Component {
     },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     resultOffset: { initialValue: 0 },
-    locations: {
-      throwErrors: false,
-      type: 'okapi',
-      records: 'locations',
-      path: 'locations?limit=1000&query=cql.allRecords=1 sortby name',
-    },
     instanceTypes: {
       throwErrors: false,
       type: 'okapi',

--- a/hooks/useLocationsForTenants/useLocationsForTenants.test.js
+++ b/hooks/useLocationsForTenants/useLocationsForTenants.test.js
@@ -3,7 +3,10 @@ import {
   QueryClientProvider,
 } from 'react-query';
 
-import { useOkapiKy } from '@folio/stripes/core';
+import {
+  useOkapiKy,
+  checkIfUserInCentralTenant,
+} from '@folio/stripes/core';
 
 import {
   renderHook,
@@ -37,22 +40,58 @@ describe('useLocationsForTenants', () => {
 
   const tenantIds = ['cs00000int', 'cs00000int_0002'];
 
-  it('should fetch locations of all tenants', async () => {
-    const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
+  describe('when user is in a member tenant', () => {
+    it('should fetch locations of all tenants via multiple requests', async () => {
+      const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
 
-    await act(() => !result.current.isLoading);
+      await act(() => !result.current.isLoading);
 
-    expect(result.current.data).toEqual([
-      { id: 'location-id', _tenantId: 'cs00000int' },
-      { id: 'location-id', _tenantId: 'cs00000int_0002' },
-    ]);
+      expect(result.current.data).toEqual([
+        { id: 'location-id', tenantId: 'cs00000int' },
+        { id: 'location-id', tenantId: 'cs00000int_0002' },
+      ]);
+    });
+
+    it('should not call consolidated locations endpoint', async () => {
+      const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
+
+      await act(() => !result.current.isLoading);
+
+      expect(mockGet).not.toHaveBeenCalledWith('search/consortium/locations');
+    });
+
+    describe('when tenantIds is empty', () => {
+      it('should not make a request', () => {
+        renderHook(() => useLocationsForTenants({ tenantIds: [] }), { wrapper });
+
+        expect(mockGet).not.toHaveBeenCalled();
+      });
+    });
   });
 
-  describe('when tenantIds is empty', () => {
-    it('should not make a request', () => {
-      renderHook(() => useLocationsForTenants({ tenantIds: [] }), { wrapper });
+  describe('when user is in a central tenant', () => {
+    beforeEach(() => {
+      checkIfUserInCentralTenant.mockClear().mockReturnValue(true);
+    });
 
-      expect(mockGet).not.toHaveBeenCalled();
+    it('should fetch locations of all tenants via consolidated endpoint', async () => {
+      const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
+
+      await act(() => !result.current.isLoading);
+
+      expect(mockGet).toHaveBeenCalledWith('search/consortium/locations');
+
+      expect(result.current.data).toEqual([
+        { id: 'location-id' },
+      ]);
+    });
+
+    it('should not call multiple locations endpoints', async () => {
+      const { result } = renderHook(() => useLocationsForTenants({ tenantIds }), { wrapper });
+
+      await act(() => !result.current.isLoading);
+
+      expect(mockGet).not.toHaveBeenCalledWith('locations');
     });
   });
 });

--- a/test/jest/__mock__/stripesCore.mock.js
+++ b/test/jest/__mock__/stripesCore.mock.js
@@ -100,5 +100,7 @@ jest.mock('@folio/stripes/core', () => {
     })),
 
     checkIfUserInMemberTenant: () => true,
+
+    checkIfUserInCentralTenant: jest.fn(() => false),
   };
 }, { virtual: true });


### PR DESCRIPTION
## Description
Use consolidated locations endpoint to fetch all locations when in central tenant context.
Renamed `_tenantId` when getting locations per tenant to `tenantId` because in consolidated endpoint we get that dat automatically with that property name.

## Screenshots

https://github.com/folio-org/ui-plugin-find-instance/assets/19309423/49470236-b5c0-4a9f-a4bc-ccb7dbd49401

## Issues
[UIPFI-146](https://folio-org.atlassian.net/browse/UIPFI-146)