### PR TITLE
UIPFI-158: Use `withSearchErrors` HOC and `buildRecordsManifest` to display an error when the request URL is exceeded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add new Instance search option `Classification, normalized` for the `Instance` toggle. Refs UIPFI-149.
 * Use consolidated locations endpoint to fetch all locations when in central tenant context. Refs UIPFI-146.
 * *BREAKING* Integrate facets, use `buildSearchQuery` for building a search query from `stripes-inventory-components`.
+* Use `withSearchErrors` HOC and `buildRecordsManifest` to display an error when the request URL is exceeded. Refs UIPFI-158.
 
 ## [7.1.1](https://github.com/folio-org/ui-plugin-find-instance/tree/v7.1.1) (2024-04-01)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.1.0...v7.1.1)

--- a/src/components/FindInstanceContainer/FindInstanceContainer.js
+++ b/src/components/FindInstanceContainer/FindInstanceContainer.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
+import flowRight from 'lodash/flowRight';
 import classnames from 'classnames';
 
 import { Icon } from '@folio/stripes/components';
@@ -12,7 +13,8 @@ import {
 } from '@folio/stripes/core';
 import {
   USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
-  buildSearchQuery,
+  withSearchErrors,
+  buildRecordsManifest,
 } from '@folio/stripes-inventory-components';
 
 import css from './FindInstanceContainer.css';
@@ -71,24 +73,8 @@ class FindInstanceContainer extends React.Component {
         filters: staffSuppressFalse,
       },
     },
-    records: {
-      accumulate: 'true',
-      throwErrors: false,
-      type: 'okapi',
-      records: 'instances',
-      resultDensity: 'sparse',
-      path: 'search/instances',
-      recordsRequired: '%{resultCount}',
-      resultOffset: '%{resultOffset}',
-      perRequest: RESULT_COUNT_INCREMENT,
-      GET: {
-        params: {
-          expandAll: true,
-          query: buildSearchQuery(applyDefaultStaffSuppressFilter),
-        },
-        staticFallback: { params: {} },
-      },
-    },
+    requestUrlQuery: { initialValue: '' },
+    records: buildRecordsManifest(applyDefaultStaffSuppressFilter),
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     resultOffset: { initialValue: 0 },
     contributorTypes: {
@@ -238,4 +224,7 @@ FindInstanceContainer.propTypes = {
   resources: PropTypes.object.isRequired,
 };
 
-export default stripesConnect(FindInstanceContainer, { dataKey: 'find_instance' });
+export default flowRight(
+  (Component) => stripesConnect(Component, { dataKey: 'find_instance' }),
+  withSearchErrors,
+)(FindInstanceContainer);

--- a/src/components/FindInstanceContainer/FindInstanceContainer.test.js
+++ b/src/components/FindInstanceContainer/FindInstanceContainer.test.js
@@ -30,7 +30,10 @@ const defaultProps = {
     },
     resultOffset: {
       replace: jest.fn()
-    }
+    },
+    requestUrlQuery: {
+      replace: jest.fn(),
+    },
   },
   resources: {
     contributorTypes: {
@@ -178,7 +181,9 @@ describe('FindInstanceContainer', () => {
 
     describe('when query is not empty', () => {
       it('should return correct query parameters', () => {
-        const queryParams = 'queryParams';
+        const queryParams = {
+          qindex: 'isbn',
+        };
         const pathComponents = 'pathComponents';
         const resourceData = {
           identifier_types: {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIIN-817 Orders schema updates
-->

## Purpose
When the request URL exceeds the limit:
1. Show an error toast message;
2. Show a specific error message inside the results list.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
Export `buildRecordsManifest` to have one source of truth for ui-inventory and ui-plugin-find-instance.

Use `withSearchErrors` to show the error toast message, it also provides the `isRequestUrlExceededLimit` property for displaying correct error message in results pane.

The tests will pass once the related PRs are merged.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIPFI-158](https://folio-org.atlassian.net/browse/UIPFI-158)

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/61
https://github.com/folio-org/stripes-smart-components/pull/1496
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots
https://github.com/user-attachments/assets/6a60bced-cbc3-4d86-b78e-efe99428f664
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
