### PR TITLE
UIPFI-159: Prevent `onChange` from being triggered when clicking on the current search segment tab.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * *BREAKING* Integrate facets, use `buildSearchQuery` for building a search query from `stripes-inventory-components`.
 * Use `withSearchErrors` HOC and `buildRecordsManifest` to display an error when the request URL is exceeded. Refs UIPFI-158.
 * ECS - Accept `tenantId` prop to search entries in the specified tenant. Refs UIPFI-157.
+* Prevent `onChange` from being triggered when clicking on the current segment tab. Refs UIPFI-159.
 
 ## [7.1.1](https://github.com/folio-org/ui-plugin-find-instance/tree/v7.1.1) (2024-04-01)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.1.0...v7.1.1)

--- a/src/components/FilterNavigation/FilterNavigation.js
+++ b/src/components/FilterNavigation/FilterNavigation.js
@@ -12,7 +12,10 @@ import {
   ButtonGroup,
   Button,
 } from '@folio/stripes/components';
-import { segments } from '@folio/stripes-inventory-components';
+import {
+  handleSegmentChange,
+  segments,
+} from '@folio/stripes-inventory-components';
 
 import { AVAILABLE_SEGMENTS_TYPES } from '../../constants';
 
@@ -46,7 +49,7 @@ const FilterNavigation = ({
         segmentsForRender.map(name => (
           <Button
             key={`${name}`}
-            onClick={() => onChange(name)}
+            onClick={() => handleSegmentChange(name, segment, onChange)}
             buttonStyle={`${segment === name ? 'primary' : 'default'}`}
             id={`segment-navigation-${name}`}
           >

--- a/src/components/FilterNavigation/FilterNavigation.test.js
+++ b/src/components/FilterNavigation/FilterNavigation.test.js
@@ -20,6 +20,16 @@ describe('FilterNavigation', () => {
     onChange: mockOnChange,
     setSegment: mockedSetSegment,
   };
+
+  const renderFilterNavigation = (props = {}) => render(
+    <FilterNavigation
+      segment={segments.instances}
+      onChange={mockOnChange}
+      setSegment={mockedSetSegment}
+      {...props}
+    />
+  );
+
   const getButton = (segment) => within(screen.getByTestId(buttonGroupTestId)).getByText(`ui-plugin-find-instance.filters.${segment}`);
   const testSegments = (segmentsForTest, activeSegment) => {
     segmentsForTest.forEach((segment, index) => {
@@ -117,6 +127,28 @@ describe('FilterNavigation', () => {
       });
 
       testSegments(segmentsForTest, segments.holdings);
+    });
+  });
+
+  describe('when pressing the current segment', () => {
+    it('should not fire onChange', () => {
+      const { getByRole } = renderFilterNavigation();
+
+      const instanceSegment = getByRole('button', { name: 'ui-plugin-find-instance.filters.instances' });
+      fireEvent.click(instanceSegment);
+
+      expect(mockOnChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when clicking another segment', () => {
+    it('should fire onChange', () => {
+      const { getByRole } = renderFilterNavigation();
+
+      const holdingsSegment = getByRole('button', { name: 'ui-plugin-find-instance.filters.holdings' });
+      fireEvent.click(holdingsSegment);
+
+      expect(mockOnChange).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/FilterNavigation/FilterNavigation.test.js
+++ b/src/components/FilterNavigation/FilterNavigation.test.js
@@ -43,14 +43,6 @@ describe('FilterNavigation', () => {
         }), {});
         expect(button).toBeInTheDocument();
       });
-
-      it(`should correctly process click on ${segment} button`, () => {
-        const button = getButton(segment);
-
-        fireEvent.click(button);
-
-        expect(mockOnChange).toHaveBeenCalled();
-      });
     });
   };
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIPFI-26: Add pull request template
-->

<!--
  You have added reviewers to the pull request.
  Required reviewers this is a personal that responsible for current repository
  in according with https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix
-->

## Purpose
Be able to see facet options after clicking on the current search segment tab (Instance/Holdings/Item) and then opening the facet.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Description
If a user clicks a current search segment or search mode, do nothing.

Tests will pass after the related PR is merged.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/67

## Refs
[UIPFI-159](https://folio-org.atlassian.net/browse/UIPFI-159)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIPFI-26
-->

## Screenshots

https://github.com/user-attachments/assets/711d6c25-2763-4f8d-8408-1fc77d21a6b6



<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
