### PR TITLE
UIPFI-160: Add a sort indicator next to the sortable search headers of search results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * ECS - Accept `tenantId` prop to search entries in the specified tenant. Refs UIPFI-157.
 * Prevent `onChange` from being triggered when clicking on the current segment tab. Refs UIPFI-159.
 * Add `setQueryOnMount` and `initialSortState` props for `SearchAndSortQuery` to apply initial sort state from Inventory settings. Refs UIPFI-161.
+* Add a sort indicator next to the sortable search headers of search results. Refs UIPFI-160.
 
 ## [7.1.1](https://github.com/folio-org/ui-plugin-find-instance/tree/v7.1.1) (2024-04-01)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.1.0...v7.1.1)

--- a/src/components/FindInstanceContainer/FindInstanceContainer.js
+++ b/src/components/FindInstanceContainer/FindInstanceContainer.js
@@ -17,21 +17,27 @@ import {
   buildRecordsManifest,
 } from '@folio/stripes-inventory-components';
 
+import { SEARCH_RESULTS_COLUMNS } from '../../constants';
+
 import css from './FindInstanceContainer.css';
 
 const INITIAL_RESULT_COUNT = 100;
 const RESULT_COUNT_INCREMENT = 100;
 const columnWidths = {
-  isChecked: '8%',
-  title: '40%',
-  contributors: '32%',
-  publishers: '20%',
+  [SEARCH_RESULTS_COLUMNS.IS_CHECKED]: '8%',
+  [SEARCH_RESULTS_COLUMNS.TITLE]: '40%',
+  [SEARCH_RESULTS_COLUMNS.CONTRIBUTORS]: '32%',
+  [SEARCH_RESULTS_COLUMNS.PUBLISHERS]: '20%',
 };
-const visibleColumns = ['title', 'contributors', 'publishers'];
+const visibleColumns = [
+  SEARCH_RESULTS_COLUMNS.TITLE,
+  SEARCH_RESULTS_COLUMNS.CONTRIBUTORS,
+  SEARCH_RESULTS_COLUMNS.PUBLISHERS,
+];
 const columnMapping = {
-  title: <FormattedMessage id="ui-plugin-find-instance.instances.columns.title" />,
-  contributors: <FormattedMessage id="ui-plugin-find-instance.instances.columns.contributors" />,
-  publishers: <FormattedMessage id="ui-plugin-find-instance.instances.columns.publishers" />,
+  [SEARCH_RESULTS_COLUMNS.TITLE]: <FormattedMessage id="ui-plugin-find-instance.instances.columns.title" />,
+  [SEARCH_RESULTS_COLUMNS.CONTRIBUTORS]: <FormattedMessage id="ui-plugin-find-instance.instances.columns.contributors" />,
+  [SEARCH_RESULTS_COLUMNS.PUBLISHERS]: <FormattedMessage id="ui-plugin-find-instance.instances.columns.publishers" />,
 };
 
 const idPrefix = 'uiPluginFindInstance-';
@@ -168,7 +174,7 @@ class FindInstanceContainer extends React.Component {
     const contributorTypes = get(resources, 'contributorTypes.records') || [];
 
     const resultsFormatter = {
-      title: ({ title, shared }) => (
+      [SEARCH_RESULTS_COLUMNS.TITLE]: ({ title, shared }) => (
         <div className={css.titleContainer}>
           <AppIcon
             size="small"
@@ -189,8 +195,8 @@ class FindInstanceContainer extends React.Component {
           }
         </div>
       ),
-      contributors: r => contributorsFormatter(r, contributorTypes),
-      publishers: r => (r?.publication ?? []).map(p => (p ? `${p.publisher} ${p.dateOfPublication ? `(${p.dateOfPublication})` : ''}` : '')).join(', '),
+      [SEARCH_RESULTS_COLUMNS.CONTRIBUTORS]: r => contributorsFormatter(r, contributorTypes),
+      [SEARCH_RESULTS_COLUMNS.PUBLISHERS]: r => (r?.publication ?? []).map(p => (p ? `${p.publisher} ${p.dateOfPublication ? `(${p.dateOfPublication})` : ''}` : '')).join(', '),
     };
 
     if (this.source) {

--- a/src/components/PluginFindRecord/PluginFindRecordModal.js
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.js
@@ -32,15 +32,21 @@ import {
 import {
   deleteFacetStates,
   resetFacetStates,
+  SORT_OPTIONS,
   USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
 } from '@folio/stripes-inventory-components';
 
 import { FilterNavigation } from '../FilterNavigation';
-import { CONFIG_TYPES } from '../../constants';
+import {
+  CONFIG_TYPES,
+  SEARCH_RESULTS_COLUMNS,
+} from '../../constants';
 
 import css from './PluginFindRecordModal.css';
 
 const RESULTS_HEADER = <FormattedMessage id="ui-plugin-find-instance.resultsHeader" />;
+const SORTABLE_COLUMNS = Object.values(SORT_OPTIONS).filter(option => option !== SORT_OPTIONS.RELEVANCE);
+const NON_INTERACTIVE_HEADERS = Object.values(SEARCH_RESULTS_COLUMNS).filter(column => !SORTABLE_COLUMNS.includes(column));
 
 const reduceCheckedRecords = (records, isChecked = false) => {
   const recordsReducer = (accumulator, record) => {
@@ -267,7 +273,7 @@ class PluginFindRecordModal extends React.Component {
     } = config;
     const { totalRecords } = data;
     const checkedRecordsLength = Object.keys(checkedMap).length;
-    const builtVisibleColumns = isMultiSelect ? ['isChecked', ...visibleColumns] : visibleColumns;
+    const builtVisibleColumns = isMultiSelect ? [SEARCH_RESULTS_COLUMNS.IS_CHECKED, ...visibleColumns] : visibleColumns;
 
     const records = source?.recordsObj?.records || [];
 
@@ -303,7 +309,7 @@ class PluginFindRecordModal extends React.Component {
     });
 
     const mixedResultsFormatter = {
-      isChecked: record => (
+      [SEARCH_RESULTS_COLUMNS.IS_CHECKED]: record => (
         <Checkbox
           type="checkbox"
           checked={Boolean(checkedMap[record.id])}
@@ -473,7 +479,7 @@ class PluginFindRecordModal extends React.Component {
                     >
                       <MultiColumnList
                         columnMapping={{
-                          isChecked: (
+                          [SEARCH_RESULTS_COLUMNS.IS_CHECKED]: (
                             <Checkbox
                               checked={isAllChecked}
                               data-test-find-records-modal-select-all
@@ -493,6 +499,8 @@ class PluginFindRecordModal extends React.Component {
                         onHeaderClick={onSort}
                         onNeedMoreData={onNeedMoreData}
                         onRowClick={this.onRowClick}
+                        showSortIndicator
+                        nonInteractiveHeaders={NON_INTERACTIVE_HEADERS}
                         sortDirection={sortOrder.startsWith('-') ? 'descending' : 'ascending'}
                         sortOrder={sortOrder.replace(/^-/, '').replace(/,.*/, '')}
                         totalCount={totalRecords}

--- a/src/components/PluginFindRecord/PluginFindRecordModal.test.js
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.test.js
@@ -133,6 +133,19 @@ describe('Plugin find record modal', () => {
     expect(stripesComponents.MultiColumnList).toHaveBeenLastCalledWith(expect.objectContaining(expectedProps), {});
   });
 
+  it('should have a sort indicator in MCL', () => {
+    jest.spyOn(stripesComponents, 'MultiColumnList');
+
+    const expectedProps = {
+      showSortIndicator: true,
+      nonInteractiveHeaders: ['publishers', 'isChecked'],
+    };
+
+    renderPluginFindRecordModal();
+
+    expect(stripesComponents.MultiColumnList).toHaveBeenLastCalledWith(expect.objectContaining(expectedProps), {});
+  });
+
   describe('With default props', () => {
     let pluginFindRecordModal;
 

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,6 +1,9 @@
 import PropTypes from 'prop-types';
 
-import { segments } from '@folio/stripes-inventory-components';
+import {
+  segments,
+  SORT_OPTIONS,
+} from '@folio/stripes-inventory-components';
 
 export const AVAILABLE_SEGMENTS_TYPES = PropTypes.arrayOf(
   PropTypes.shape({
@@ -11,3 +14,10 @@ export const AVAILABLE_SEGMENTS_TYPES = PropTypes.arrayOf(
 export const CONFIG_TYPES = PropTypes.shape({
   availableSegments: AVAILABLE_SEGMENTS_TYPES,
 });
+
+export const SEARCH_RESULTS_COLUMNS = {
+  TITLE: SORT_OPTIONS.TITLE,
+  CONTRIBUTORS: SORT_OPTIONS.CONTRIBUTORS,
+  PUBLISHERS: 'publishers',
+  IS_CHECKED: 'isChecked',
+};


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIPFI-26: Add pull request template
-->

<!--
  You have added reviewers to the pull request.
  Required reviewers this is a personal that responsible for current repository
  in according with https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix
-->

## Purpose
Add a sort indicator next to the sortable search headers of search results.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Approach
Add `showSortIndicator` to MCL, this will add a sort indicator for all headings.
Add `nonInteractiveHeaders` to remove a sort indicator from the non-interactive headers.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIPFI-160](https://folio-org.atlassian.net/browse/UIPFI-160)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIPFI-26
-->

## Screenshots
![image](https://github.com/user-attachments/assets/21e5b747-6eb0-4810-828e-1f00a613f756)

<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
