### PR TITLE
UIPFI-162: Add Date column to Inventory results list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Prevent `onChange` from being triggered when clicking on the current segment tab. Refs UIPFI-159.
 * Add `setQueryOnMount` and `initialSortState` props for `SearchAndSortQuery` to apply initial sort state from Inventory settings. Refs UIPFI-161.
 * Add a sort indicator next to the sortable search headers of search results. Refs UIPFI-160.
+* Add Date column to Inventory results list. Refs UIPFI-162.
 
 ## [7.1.1](https://github.com/folio-org/ui-plugin-find-instance/tree/v7.1.1) (2024-04-01)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.1.0...v7.1.1)

--- a/src/FindInstance.js
+++ b/src/FindInstance.js
@@ -107,6 +107,7 @@ const FindInstance = ({
             <FindInstanceContainer
               segment={segment}
               tenantId={currentTenantId}
+              contextData={contextData}
             >
               {(viewProps) => (
                 <PluginFindRecordModal

--- a/src/components/FindInstanceContainer/FindInstanceContainer.js
+++ b/src/components/FindInstanceContainer/FindInstanceContainer.js
@@ -15,6 +15,9 @@ import {
   USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
   withSearchErrors,
   buildRecordsManifest,
+  SEARCH_COLUMN_MAPPINGS,
+  SEARCH_VISIBLE_COLUMNS,
+  getSearchResultsFormatter,
 } from '@folio/stripes-inventory-components';
 
 import { SEARCH_RESULTS_COLUMNS } from '../../constants';
@@ -28,16 +31,6 @@ const columnWidths = {
   [SEARCH_RESULTS_COLUMNS.TITLE]: '40%',
   [SEARCH_RESULTS_COLUMNS.CONTRIBUTORS]: '32%',
   [SEARCH_RESULTS_COLUMNS.PUBLISHERS]: '20%',
-};
-const visibleColumns = [
-  SEARCH_RESULTS_COLUMNS.TITLE,
-  SEARCH_RESULTS_COLUMNS.CONTRIBUTORS,
-  SEARCH_RESULTS_COLUMNS.PUBLISHERS,
-];
-const columnMapping = {
-  [SEARCH_RESULTS_COLUMNS.TITLE]: <FormattedMessage id="ui-plugin-find-instance.instances.columns.title" />,
-  [SEARCH_RESULTS_COLUMNS.CONTRIBUTORS]: <FormattedMessage id="ui-plugin-find-instance.instances.columns.contributors" />,
-  [SEARCH_RESULTS_COLUMNS.PUBLISHERS]: <FormattedMessage id="ui-plugin-find-instance.instances.columns.publishers" />,
 };
 
 const idPrefix = 'uiPluginFindInstance-';
@@ -170,10 +163,12 @@ class FindInstanceContainer extends React.Component {
       resources,
       children,
       tenantId,
+      contextData,
     } = this.props;
     const contributorTypes = get(resources, 'contributorTypes.records') || [];
 
     const resultsFormatter = {
+      ...getSearchResultsFormatter(contextData),
       [SEARCH_RESULTS_COLUMNS.TITLE]: ({ title, shared }) => (
         <div className={css.titleContainer}>
           <AppIcon
@@ -204,7 +199,7 @@ class FindInstanceContainer extends React.Component {
     }
 
     return children({
-      columnMapping,
+      columnMapping: SEARCH_COLUMN_MAPPINGS,
       columnWidths,
       idPrefix,
       modalLabel,
@@ -213,7 +208,7 @@ class FindInstanceContainer extends React.Component {
       querySetter: this.querySetter,
       resultsFormatter,
       source: this.source,
-      visibleColumns,
+      visibleColumns: SEARCH_VISIBLE_COLUMNS,
       index: this.state.index,
       pageSize: RESULT_COUNT_INCREMENT,
       tenantId,
@@ -227,6 +222,7 @@ class FindInstanceContainer extends React.Component {
 }
 
 FindInstanceContainer.propTypes = {
+  contextData: PropTypes.object.isRequired,
   stripes: PropTypes.object.isRequired,
   children: PropTypes.func,
   mutator: PropTypes.object.isRequired,

--- a/src/components/FindInstanceContainer/FindInstanceContainer.test.js
+++ b/src/components/FindInstanceContainer/FindInstanceContainer.test.js
@@ -75,7 +75,10 @@ const defaultProps = {
     logger: {
       log: jest.fn()
     }
-  }
+  },
+  contextData: {
+    instanceDateTypes: [],
+  },
 };
 const contributorsData = {
   contributors: [

--- a/src/components/PluginFindRecord/PluginFindRecordModal.test.js
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.test.js
@@ -30,6 +30,7 @@ const contextData = {
   displaySettings: {
     defaultSort: SORT_OPTIONS.CONTRIBUTORS,
   },
+  instanceDateTypes: [],
 };
 
 const renderPluginFindRecordModal = ({

--- a/src/components/PluginFindRecord/PluginFindRecordModal.test.js
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.test.js
@@ -139,7 +139,7 @@ describe('Plugin find record modal', () => {
 
     const expectedProps = {
       showSortIndicator: true,
-      nonInteractiveHeaders: ['publishers', 'isChecked'],
+      nonInteractiveHeaders: expect.arrayContaining(['publishers', 'isChecked']),
     };
 
     renderPluginFindRecordModal();

--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 import {
   segments,
-  SORT_OPTIONS,
+  SEARCH_COLUMN_NAMES,
 } from '@folio/stripes-inventory-components';
 
 export const AVAILABLE_SEGMENTS_TYPES = PropTypes.arrayOf(
@@ -16,8 +16,6 @@ export const CONFIG_TYPES = PropTypes.shape({
 });
 
 export const SEARCH_RESULTS_COLUMNS = {
-  TITLE: SORT_OPTIONS.TITLE,
-  CONTRIBUTORS: SORT_OPTIONS.CONTRIBUTORS,
-  PUBLISHERS: 'publishers',
+  ...SEARCH_COLUMN_NAMES,
   IS_CHECKED: 'isChecked',
 };

--- a/test/jest/__mock__/stripesInventoryComponents.mock.js
+++ b/test/jest/__mock__/stripesInventoryComponents.mock.js
@@ -16,6 +16,7 @@ jest.mock('@folio/stripes-inventory-components', () => ({
       displaySettings: {
         defaultSort: 'title',
       },
+      instanceDateTypes: [],
     },
     isCommonDataLoading: false,
   }),

--- a/translations/ui-plugin-find-instance/en.json
+++ b/translations/ui-plugin-find-instance/en.json
@@ -72,8 +72,5 @@
   "itemEffectiveCallNumberEyeReadable": "Effective call number (item), eye readable",
   "itemEffectiveCallNumberNormalized": "Effective call number (item), normalized",
   "itemHrid": "Item HRID",
-  "instances.columns.title": "Title",
-  "instances.columns.contributors": "Contributors",
-  "instances.columns.publishers": "Publishers",
   "communicationProblem": "Server communication problem. Please try again"
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIPFI-26: Add pull request template
-->

<!--
  You have added reviewers to the pull request.
  Required reviewers this is a personal that responsible for current repository
  in according with https://wiki.folio.org/display/REL/Team+vs+module+responsibility+matrix
-->

## Purpose
Add Date column to Inventory results list.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Related PRs
https://github.com/folio-org/stripes-inventory-components/pull/71

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIPFI-162](https://folio-org.atlassian.net/browse/UIPFI-162)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIPFI-26
-->

## Screenshots


![image](https://github.com/user-attachments/assets/616f7e09-f9b2-4a68-b2d1-2010e8391cb0)


<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.
-->

<!-- OPTIONAL
#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

<!-- OPTIONAL
## Learning
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
