### PR TITLE
UIPFI-164: Use `ResetProvider` to subscribe and publish the reset event and unsubscribe from it after a segment switch.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Add a sort indicator next to the sortable search headers of search results. Refs UIPFI-160.
 * Add Date column to Inventory results list. Refs UIPFI-162.
 * Add a label to search input. Fixes UIPFI-142.
+* Use `ResetProvider` to subscribe and publish the reset event and unsubscribe from it after a segment switch. Refs UIPFI-164.
 
 ## [7.1.1](https://github.com/folio-org/ui-plugin-find-instance/tree/v7.1.1) (2024-04-01)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.1.0...v7.1.1)

--- a/src/FindInstance.js
+++ b/src/FindInstance.js
@@ -16,6 +16,7 @@ import {
   filterConfig,
   queryIndexes,
   renderFilters,
+  ResetProvider,
   segments,
   USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
 } from '@folio/stripes-inventory-components';
@@ -95,45 +96,47 @@ const FindInstance = ({
   }, [isError, error]);
 
   return (
-    <PluginFindRecord
-      {...rest}
-      onClose={onClose}
-      tenantId={tenantId}
-      selectRecordsCb={list => setInstances(list)}
-    >
-      {(modalProps) => (
-        <DataContext.Consumer>
-          {contextData => (
-            <FindInstanceContainer
-              segment={segment}
-              tenantId={currentTenantId}
-              contextData={contextData}
-            >
-              {(viewProps) => (
-                <PluginFindRecordModal
-                  {...viewProps}
-                  {...modalProps}
-                  config={config}
-                  contextData={contextData}
-                  isMultiSelect={isMultiSelect}
-                  renderNewBtn={renderNewBtn}
-                  renderFilters={renderFilters({
-                    data: contextData,
-                    query: viewProps.queryGetter(),
-                    segment,
-                    tenantId,
-                    onFilterChange: handleFilterChange,
-                  })}
-                  segment={segment}
-                  setSegment={setSegment}
-                  searchIndexes={searchIndexes}
-                />
-              )}
-            </FindInstanceContainer>
-          )}
-        </DataContext.Consumer>
-      )}
-    </PluginFindRecord>
+    <ResetProvider>
+      <PluginFindRecord
+        {...rest}
+        onClose={onClose}
+        tenantId={tenantId}
+        selectRecordsCb={list => setInstances(list)}
+      >
+        {(modalProps) => (
+          <DataContext.Consumer>
+            {contextData => (
+              <FindInstanceContainer
+                segment={segment}
+                tenantId={currentTenantId}
+                contextData={contextData}
+              >
+                {(viewProps) => (
+                  <PluginFindRecordModal
+                    {...viewProps}
+                    {...modalProps}
+                    config={config}
+                    contextData={contextData}
+                    isMultiSelect={isMultiSelect}
+                    renderNewBtn={renderNewBtn}
+                    renderFilters={renderFilters({
+                      data: contextData,
+                      query: viewProps.queryGetter(),
+                      segment,
+                      tenantId,
+                      onFilterChange: handleFilterChange,
+                    })}
+                    segment={segment}
+                    setSegment={setSegment}
+                    searchIndexes={searchIndexes}
+                  />
+                )}
+              </FindInstanceContainer>
+            )}
+          </DataContext.Consumer>
+        )}
+      </PluginFindRecord>
+    </ResetProvider>
   );
 };
 

--- a/src/components/PluginFindRecord/PluginFindRecordModal.js
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.js
@@ -34,6 +34,7 @@ import {
   resetFacetStates,
   SORT_OPTIONS,
   USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY,
+  withReset,
 } from '@folio/stripes-inventory-components';
 
 import { FilterNavigation } from '../FilterNavigation';
@@ -220,23 +221,29 @@ class PluginFindRecordModal extends React.Component {
   }
 
   handleResetAll = (cb) => () => {
-    const { namespace } = this.props;
+    const {
+      namespace,
+      publishOnReset,
+    } = this.props;
 
     resetFacetStates({ namespace });
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
     cb();
+    publishOnReset();
   }
 
   handleSearchSegmentChange = (resetAll) => (name) => {
     const {
       setSegment,
       namespace,
+      unsubscribeFromReset,
     } = this.props;
 
     deleteFacetStates(namespace);
     sessionStorage.setItem(USER_TOUCHED_STAFF_SUPPRESS_STORAGE_KEY, false);
     setSegment(name);
     resetAll();
+    unsubscribeFromReset();
   }
 
   render() {
@@ -413,7 +420,7 @@ class PluginFindRecordModal extends React.Component {
                   }
 
                   onSort(e, meta);
-                }
+                };
 
                 return (
                   <Paneset
@@ -544,6 +551,7 @@ PluginFindRecordModal.propTypes = {
   onNeedMoreData: PropTypes.func,
   onSaveMultiple: PropTypes.func,
   onSelectRow: PropTypes.func,
+  publishOnReset: PropTypes.func.isRequired,
   queryGetter: PropTypes.func,
   querySetter: PropTypes.func,
   renderFilters: PropTypes.func,
@@ -553,6 +561,7 @@ PluginFindRecordModal.propTypes = {
   segment: PropTypes.string,
   setSegment: PropTypes.func.isRequired,
   source: PropTypes.object,
+  unsubscribeFromReset: PropTypes.func.isRequired,
   visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
   config: CONFIG_TYPES,
   pageSize: PropTypes.number,
@@ -577,4 +586,5 @@ PluginFindRecordModal.defaultProps = {
 export default flowRight(
   withNamespace,
   injectIntl,
+  withReset,
 )(PluginFindRecordModal);

--- a/src/components/PluginFindRecord/PluginFindRecordModal.test.js
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.test.js
@@ -30,6 +30,8 @@ jest.mock('@folio/stripes-inventory-components', () => ({
       publishOnReset={mockPublishOnReset}
     />
   ),
+  resetFacetStates: jest.fn(),
+  resetFacetSearchValue: jest.fn(),
 }));
 
 const config = [{

--- a/src/components/PluginFindRecord/PluginFindRecordModal.test.js
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.test.js
@@ -6,13 +6,31 @@ import {
   screen,
   fireEvent,
 } from '@folio/jest-config-stripes/testing-library/react';
+import userEvent from '@folio/jest-config-stripes/testing-library/user-event';
 
 import stripesComponents from '@folio/stripes/components';
 import smartComponents from '@folio/stripes/smart-components';
-import { SORT_OPTIONS } from '@folio/stripes-inventory-components';
+import {
+  ResetProvider,
+  SORT_OPTIONS,
+} from '@folio/stripes-inventory-components';
 
 import PluginFindRecordModal from './PluginFindRecordModal';
 import css from './PluginFindRecordModal.css';
+
+const mockUnsubscribeFromReset = jest.fn();
+const mockPublishOnReset = jest.fn();
+
+jest.mock('@folio/stripes-inventory-components', () => ({
+  ...jest.requireActual('@folio/stripes-inventory-components'),
+  withReset: (Comp) => (props) => (
+    <Comp
+      {...props}
+      unsubscribeFromReset={mockUnsubscribeFromReset}
+      publishOnReset={mockPublishOnReset}
+    />
+  ),
+}));
 
 const config = [{
   label: 'Item Types',
@@ -59,27 +77,29 @@ const renderPluginFindRecordModal = ({
   filterConfig = [],
 } = {}) => render(
   <MemoryRouter>
-    <PluginFindRecordModal
-      contextData={contextData}
-      className={css.pluginModalContent}
-      idPrefix={idPrefix}
-      isMultiSelect={isMultiSelect}
-      filterConfig={filterConfig}
-      setSegment={setSegment}
-      visibleColumns={visibleColumns}
-      closeModal={closeModal}
-      modalLabel={label}
-      intl={intl}
-      onComponentWillUnmount={onComponentWillUnmount}
-      onNeedMoreData={onNeedMoreData}
-      onSelectRow={onSelectRow}
-      queryGetter={queryGetter}
-      renderFilters={renderFilters}
-      renderNewBtn={renderNewBtn}
-      querySetter={querySetter}
-      source={source}
-      searchIndexes={searchIndexes}
-    />
+    <ResetProvider>
+      <PluginFindRecordModal
+        contextData={contextData}
+        className={css.pluginModalContent}
+        idPrefix={idPrefix}
+        isMultiSelect={isMultiSelect}
+        filterConfig={filterConfig}
+        setSegment={setSegment}
+        visibleColumns={visibleColumns}
+        closeModal={closeModal}
+        modalLabel={label}
+        intl={intl}
+        onComponentWillUnmount={onComponentWillUnmount}
+        onNeedMoreData={onNeedMoreData}
+        onSelectRow={onSelectRow}
+        queryGetter={queryGetter}
+        renderFilters={renderFilters}
+        renderNewBtn={renderNewBtn}
+        querySetter={querySetter}
+        source={source}
+        searchIndexes={searchIndexes}
+      />
+    </ResetProvider>
   </MemoryRouter>
 );
 
@@ -145,6 +165,27 @@ describe('Plugin find record modal', () => {
     renderPluginFindRecordModal();
 
     expect(stripesComponents.MultiColumnList).toHaveBeenLastCalledWith(expect.objectContaining(expectedProps), {});
+  });
+
+  describe('when hitting the reset button', () => {
+    it('should publish the reset event', async () => {
+      const { getByText, getByRole } = renderPluginFindRecordModal();
+
+      await userEvent.type(getByRole('searchbox', { name: /stripes-smart-components.search/i }), 'foo');
+      await userEvent.click(getByText('stripes-smart-components.resetAll'));
+
+      expect(mockPublishOnReset).toHaveBeenCalled();
+    });
+  });
+
+  describe('when changing a segment', () => {
+    it('should unsubscribe from the reset event', async () => {
+      const { getByText } = renderPluginFindRecordModal();
+
+      await userEvent.click(getByText('ui-plugin-find-instance.filters.holdings'));
+
+      expect(mockUnsubscribeFromReset).toHaveBeenCalled();
+    });
   });
 
   describe('With default props', () => {


### PR DESCRIPTION
## Purpose
Date filters: Clear dates after pressing the reset search button even if values are invalid.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
 -->

## Related PRs
https://github.com/folio-org/stripes-smart-components/pull/1527
https://github.com/folio-org/stripes-inventory-components/pull/83

## Approach
Use `ResetProvider` to publish the reset event and subscribe to it in filters.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

## Refs
[UIIN-3093](https://folio-org.atlassian.net/browse/UIIN-3093)
<!--
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIIN-817
-->

## Screenshots

https://github.com/user-attachments/assets/ca890dd9-6021-431c-8dc9-bee7946d1293