### PR TITLE
UIPFI-169 Use an empty string as a default sort parameter when Display Settings has `relevance` as a default sort.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Remove callbacks that reset facets states. Fixes UIPFI-163.
 
+## [8.0.1] IN PROGRESS
+
+* Use an empty string as a default sort parameter when Display Settings has `relevance` as a default sort. Fixes UIPFI-169.
+
 ## [8.0.0](https://github.com/folio-org/ui-plugin-find-instance/tree/v8.0.0) (2024-10-31)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v7.1.1...v8.0.0)
 

--- a/src/components/PluginFindRecord/PluginFindRecordModal.js
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.js
@@ -273,6 +273,7 @@ class PluginFindRecordModal extends React.Component {
       availableSegments,
     } = config;
     const { totalRecords } = data;
+    const { displaySettings } = contextData;
     const checkedRecordsLength = Object.keys(checkedMap).length;
     const builtVisibleColumns = isMultiSelect ? [SEARCH_RESULTS_COLUMNS.IS_CHECKED, ...visibleColumns] : visibleColumns;
 
@@ -280,7 +281,11 @@ class PluginFindRecordModal extends React.Component {
 
     const query = queryGetter ? queryGetter() || {} : {};
     const count = source ? source.totalCount() : 0;
-    const defaultSort = contextData.displaySettings.defaultSort;
+
+    // mod-search only allows sorting by actual Instance fields
+    // since 'relevance' is not a real field using it causes a BE error
+    // if a default sort is 'relevance' we need to use an empty string, which is treated as relevance sort on BE side
+    const defaultSort = displaySettings.defaultSort === SORT_OPTIONS.RELEVANCE ? '' : displaySettings.defaultSort;
     const sortOrder = query.sort || defaultSort;
     const resultsStatusMessage = source
       ? (


### PR DESCRIPTION
## Description
mod-search only allows sorting by actual Instance fields
since 'relevance' is not a real field using it causes a BE error. If a default sort is 'relevance' we need to use an empty string, which is treated as relevance sort on BE side

## Screenshots

https://github.com/user-attachments/assets/687d05cc-b34a-4bff-9d29-ba97bd198707


## Issues
[UIPFI-169](https://folio-org.atlassian.net/browse/UIPFI-169)