### PR TITLE
UIPFI-189 Fix scrollbar in "Select instance" modal has incorrect size and does not scroll with mouse input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change history for ui-plugin-find-instance
 
 ## [10.0.0] (IN PROGRESS)
-[Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v9.0.1...v9.1.0)
+[Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v9.0.2...v10.0.0)
 
 * *BREAKING* Update for Split Search & Browse APIs. Refs UIPFI-182.
 * Hide staff suppressed Instances based on existing permission for Staff suppress facet. Refs UIPFI-185.
 * ECS: Set Held by facet default to current tenant context in find instance plugin. Refs UIPFI-184.
 * Remove `expandAll=true` parameter from requests to mod-search. Refs UIPFI-190.
+* Fix scrollbar in "Select instance" modal has incorrect size and does not scroll with mouse input. Fixes UIPFI-189.
 
 ## [9.0.2](https://github.com/folio-org/ui-plugin-find-instance/tree/v9.0.2) (2025-09-17)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-instance/compare/v9.0.1...v9.0.2)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-instance",
-  "version": "9.1.0",
+  "version": "10.0.0",
   "description": "Instance-finder for Stripes",
   "repository": "folio-org/ui-plugin-find-instance",
   "publishConfig": {

--- a/src/components/PluginFindRecord/PluginFindRecordModal.css
+++ b/src/components/PluginFindRecord/PluginFindRecordModal.css
@@ -34,7 +34,7 @@
 
 .pluginModalContent {
   min-height: 400px;
-  padding: 0;
+  padding: 0 !important;
   position: relative;
 
   & [class^="paneset--"] {


### PR DESCRIPTION
## Description
Fix scrollbar in "Select instance" modal has incorrect size and does not scroll with mouse input

Screenshot of the issue: 
<img width="1440" height="733" alt="image" src="https://github.com/user-attachments/assets/3054f963-8e52-4239-a0eb-31bd25b8c859" />

Root cause of this issue is duplication/incorrect order of applied css.
Without lazy-loading (for example on Sunflower BF env) or locally we can see that there is a single CSS bundle loaded, and styles are applied from more generic to more specific: `.modalContent -> .pluginModalContent`.
<img width="819" height="366" alt="image" src="https://github.com/user-attachments/assets/6a46aef3-6e38-43c0-883e-ff5870fcd43c" />

However, when lazy-loading is applied, we load many split css files (I assume it's one per each UI module). Some of them have repeated styles, and sometimes more specific styles get overridden by generic styles that come from `stripes` components.

All of this is styles applied to a single DOM element, with multiple of the same styles duplicated and a specific class sandwiched between generic ones.
<img width="818" height="719" alt="image" src="https://github.com/user-attachments/assets/2323cacf-304a-43b2-9b5b-a337bbd50a24" />


Because `.modalContent` and `.pluginModalContent` have the same specificity - we end up in this situation where we unknowingly relied on the order of styles in our bundle to properly override some properties.

@zburke just want to let you know about this issue. I looked at the webpack configs, but nothing immediately stood out as an obvious mistake etc.

Since the `<Modal>` component renders via portals - we can't just add a wrapper around it to increase specificity and just have to go with the `!important` approach.

## Issues
[UIPFI-189](https://folio-org.atlassian.net/browse/UIPFI-189)